### PR TITLE
pipeline cleans old image + database password from config or env var

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -13,8 +13,12 @@ jobs:
           key: ${{secrets.SSH_KEY}} # Private or public key of the server
           username: ${{ secrets.SSH_USERNAME }} # User of the server
           script: |
+            config_path="backend/config/production.yaml"
             cd leadminer
             git pull
-            export DB_PASSWORD=${{secrets.DB_PASSWORD}} # Database Password
+            # Use POSTGRES_PASSWORD if defined, else get password from the config
+            DB_PASSWORD="${POSTGRES_PASSWORD:-$(niet server.postgres.password "$config_path")}"
+            export DB_PASSWORD # Database Password
             docker-compose down
+            docker rmi -f $(docker images -a | awk '/leadminer|<none>/{print $3}')
             docker-compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     expose:
       - "6666"
   leadminer:
+    image: leadminer:git
     build: .
     volumes:
       - /var/www/html/dist:/usr/src/leadminer/frontend/dist


### PR DESCRIPTION
Changes to the pipeline to make it clean old images and use database password from env variables and falls back to the config file.
the image built by docker-compose will be named leadminer to keep track of images and delete the appropriate ones (keeping redis and postgres images)