### PR TITLE
Change IP lookup method

### DIFF
--- a/.github/workflows/Selfhosted_supabase.yml
+++ b/.github/workflows/Selfhosted_supabase.yml
@@ -56,7 +56,7 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Allow through firewall
         run: |
-          RUNNER_IP="$(curl -s ifconfig.me)"
+          RUNNER_IP="$(dig +short myip.opendns.com @resolver1.opendns.com)"
           NEW_INBOUND="$(echo $INBOUND_RULES | sed "s/5432/5432,address:${RUNNER_IP}/g")"
           doctl compute firewall update $FIREWALL_ID --name supabase-firewall --inbound-rules $NEW_INBOUND --outbound-rules $OUTBOUND_RULES --droplet-ids $DROPLET_ID
 


### PR DESCRIPTION
I used 2 ip lookup services and it seems like they return an empty string on a github runner. 

Therefore I am trying a switch to `dig` to lookup the IP of the runner to be allowed through the firewall. 



There's a chance the runner replaces any variable that contains sensitive info with empty strings. But this is worth a shot.