### PR TITLE
update alternate_names query

### DIFF
--- a/supabase/migrations/20230704155042_update_query_in_refined_persons.sql
+++ b/supabase/migrations/20230704155042_update_query_in_refined_persons.sql
@@ -1,0 +1,53 @@
+CREATE
+OR REPLACE FUNCTION public.refined_persons(userid uuid) RETURNS void 
+LANGUAGE plpgsql 
+AS $function$ 
+DECLARE 
+BEGIN
+    UPDATE
+        public.refinedpersons rp
+    SET
+        engagement = sub_query.engagement,
+        recency = sub_query.recency,
+        occurence = sub_query.occurrence,
+        alternate_names = sub_query.alternate_names,
+        name = sub_query.name
+    FROM (
+        SELECT
+            poc.person_email,
+            COALESCE(nrm.recent_name, '' :: text) AS name,
+            COALESCE(
+                array_agg(DISTINCT name) FILTER (
+                    WHERE
+                        name IS NOT NULL and name <> ''
+                        AND nrm.recent_name IS NOT NULL AND nrm.recent_name <> ''
+                        AND extensions.similarity(lower(nrm.recent_name), lower(name)) < 0.7
+                ),
+                '{}' :: text []
+            ) AS alternate_names,
+            COUNT(
+                CASE
+                    WHEN m.conversation THEN 1
+                END
+            ) AS engagement,
+            MAX(m.date) AS recency,
+            COUNT(*) AS occurrence
+        FROM pointsofcontact poc
+        JOIN messages m ON poc.message_id = m.message_id
+        LEFT JOIN (
+            SELECT
+                ( array_agg(name ORDER BY m.date DESC)) [1] AS recent_name,
+                person_email
+            FROM pointsofcontact poc
+            JOIN messages m ON poc.message_id = m.message_id
+            WHERE name <> ''
+                AND name IS NOT NULL
+                AND poc.user_id = refined_persons.userid
+            GROUP BY person_email
+        ) nrm ON poc.person_email = nrm.person_email
+        WHERE poc.user_id = refined_persons.userid
+        GROUP BY poc.person_email, nrm.recent_name
+    ) sub_query
+    WHERE rp.email = sub_query.person_email;
+END;
+$function$;


### PR DESCRIPTION
- resolves #965
- should improve performance related to #969  

Removed redundant `JOIN` that causes to return more records because of grouping by lower(name). And used the name directly from the main query to aggregate alternate_names.
```sql
  LEFT JOIN (
      SELECT (array_agg(name)) [1] AS alternate_name, person_email
      FROM pointsofcontact poc
      WHERE name <> ''
          AND name IS NOT NULL
          AND poc.user_id = refined_persons.userid
      GROUP BY person_email, lower(name)
  ) gn ON poc.person_email = gn.person_email
``` 
Execution time dropped from `3s 607ms` to `1s 145ms` testing on tables:
-  `messages: 63053 | persons: 2314 | pointsofcontacts: 22854 | refinedpersons: 2314 | tags: 4000`