### PR TITLE
fix table's loading

### DIFF
--- a/frontend/src/components/Mining/Table/MiningTable.vue
+++ b/frontend/src/components/Mining/Table/MiningTable.vue
@@ -40,8 +40,8 @@
     @row-select="onRowSelect"
     @row-unselect="onRowUnselect"
   >
-    <template v-if="!isLoading" #empty>
-      <div class="text-center py-5">
+    <template #empty>
+      <div v-if="!isLoading" class="text-center py-5">
         <div class="font-semibold">{{ t('no_contacts_found') }}</div>
         <div
           v-if="filtersStore.areToggledFilters !== 0 && contactsLength !== 0"
@@ -51,7 +51,8 @@
       </div>
     </template>
     <template #loading>
-      <div class="text-center">
+      <TableSkeleton v-if="tablePosTop === 0" />
+      <div v-else class="text-center">
         <ProgressSpinner />
         <div class="font-semibold text-white">{{ loadingLabel }}</div>
       </div>
@@ -607,6 +608,8 @@ import {
   getStatusColor,
 } from '~/utils/contacts';
 import { saveCSVFile } from '~/utils/csv';
+
+const TableSkeleton = defineAsyncComponent(() => import('./TableSkeleton.vue'));
 
 const SocialLinks = defineAsyncComponent(
   () => import('../../icons/SocialLink.vue'),

--- a/frontend/src/components/Mining/Table/TableSkeleton.vue
+++ b/frontend/src/components/Mining/Table/TableSkeleton.vue
@@ -5,6 +5,7 @@
     striped-rows
     paginator
     size="small"
+    class="h-full bg-white border-x"
     scroll-height="flex"
     pt:tablecontainer:class="grow"
     paginator-template="FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink CurrentPageReport RowsPerPageDropdown"
@@ -14,20 +15,10 @@
     <template #header>
       <div class="flex items-center gap-1">
         <div>
-          <Skeleton
-            v-if="$screenStore.size.md"
-            height="2rem"
-            width="5rem"
-          ></Skeleton>
-          <Skeleton v-else size="1.5rem"></Skeleton>
+          <Skeleton height="2rem" width="2rem" class="md:!w-20"></Skeleton>
         </div>
         <div>
-          <Skeleton
-            v-if="$screenStore.size.md"
-            height="2rem"
-            width="5rem"
-          ></Skeleton>
-          <Skeleton v-else size="1.5rem"></Skeleton>
+          <Skeleton height="2rem" width="2rem" class="md:!w-20"></Skeleton>
         </div>
         <div class="ml-2 flex items-center gap-1">
           <Skeleton width="2rem" height="0.5rem"></Skeleton>
@@ -35,25 +26,18 @@
         </div>
         <div class="grow" />
         <div>
-          <Skeleton
-            v-if="$screenStore.size.md"
-            height="2rem"
-            width="5rem"
-          ></Skeleton>
-          <Skeleton v-else size="1.5rem"></Skeleton>
+          <Skeleton height="2rem" width="2rem" class="md:!w-20"></Skeleton>
         </div>
         <div>
-          <Skeleton v-if="$screenStore.size.md" size="2rem"></Skeleton>
-          <Skeleton v-else size="1.5rem"></Skeleton>
+          <Skeleton size="2rem"></Skeleton>
         </div>
         <div>
-          <Skeleton v-if="$screenStore.size.md" size="2rem"></Skeleton>
-          <Skeleton v-else size="1.5rem"></Skeleton>
+          <Skeleton size="2rem"></Skeleton>
         </div>
       </div>
     </template>
     <!-- Checkbox -->
-    <Column style="width: 38px">
+    <Column style="width: 38px" class="hidden md:table-cell">
       <template #header>
         <Skeleton size="1.2rem"></Skeleton>
       </template>
@@ -65,66 +49,36 @@
     <Column>
       <template #header>
         <div>
-          <Skeleton
-            v-if="$screenStore.size.md"
-            height="2rem"
-            width="16rem"
-          ></Skeleton>
-          <Skeleton v-else height="1.5rem" width="10rem"></Skeleton>
+          <Skeleton height="2rem" width="8rem" class="md:!w-64"></Skeleton>
         </div>
       </template>
       <template #body>
         <div class="flex justify-between items-center">
           <div class="flex items-center gap-2 grow">
-            <Skeleton
-              v-if="$screenStore.size.md"
-              shape="circle"
-              size="2rem"
-            ></Skeleton>
-            <Skeleton v-else shape="circle" size="1.5rem"></Skeleton>
+            <Skeleton shape="circle" size="2rem"></Skeleton>
             <span>
               <div class="flex pb-3">
-                <Skeleton
-                  v-if="$screenStore.size.md"
-                  height="0.5rem"
-                  width="5rem"
-                ></Skeleton>
-                <Skeleton v-else height="0.5rem" width="3rem"></Skeleton>
+                <Skeleton height="0.5rem" width="5rem"></Skeleton>
               </div>
-              <Skeleton
-                v-if="$screenStore.size.md"
-                height="0.5rem"
-                width="10rem"
-              ></Skeleton>
-              <Skeleton v-else height="0.5rem" width="5rem"></Skeleton>
+              <Skeleton height="0.5rem" width="10rem"></Skeleton>
             </span>
           </div>
-          <div v-if="$screenStore.size.md" class="flex gap-2 pt-1 pl-2">
+          <div class="flex gap-2 pt-1 pl-2">
             <Skeleton shape="circle" size="2rem"></Skeleton>
             <Skeleton shape="circle" size="2rem"></Skeleton>
             <Skeleton size="2rem"></Skeleton>
-          </div>
-          <div v-else class="flex gap-2 pt-1 pl-2">
-            <Skeleton shape="circle" size="1.5rem"></Skeleton>
-            <Skeleton shape="circle" size="1.5rem"></Skeleton>
-            <Skeleton size="1.5rem"></Skeleton>
           </div>
         </div>
       </template>
     </Column>
     <!-- Other -->
-    <div v-if="$screenStore.size.md">
-      <Column v-for="n in 5" :key="n">
-        <template #header>
-          <Skeleton></Skeleton>
-        </template>
-        <template #body>
-          <Skeleton></Skeleton>
-        </template>
-      </Column>
-    </div>
+    <Column class="hidden md:table-cell">
+      <template #header>
+        <Skeleton></Skeleton>
+      </template>
+      <template #body>
+        <Skeleton></Skeleton>
+      </template>
+    </Column>
   </DataTable>
 </template>
-<script setup lang="ts">
-const $screenStore = useScreenStore();
-</script>


### PR DESCRIPTION
- fix #1452
- fix #1593
- fix #1591
- ~~use builtin `loading` prop instead of standalone skeleton component~~
  - use `TableSkeleton` in the builtin `#loading` slot 
- stop watchers when able