### PR TITLE
stepper mobile: step name pop over step number

### DIFF
--- a/frontend/src/components/Mining/MiningStepper.vue
+++ b/frontend/src/components/Mining/MiningStepper.vue
@@ -18,39 +18,50 @@
     </template>
     <Stepper v-model:value="$stepper.index" linear>
       <StepList>
-        <Step v-tooltip.bottom="t('source')" :value="1">
-          <span class="hidden md:block">
-            {{ t('source') }}
-          </span>
+        <Step v-slot="{ active, value }" as-child :value="1">
+          <StepWithTooltip
+            :step-number="value"
+            :is-active="active"
+            :title="t('source')"
+          />
         </Step>
-        <Step v-tooltip.bottom="t('common.mine')" :value="2">
-          <span class="hidden md:block">
-            {{ $t('common.mine') }}
-          </span>
+        <Step v-slot="{ active, value }" as-child :value="2">
+          <StepWithTooltip
+            :step-number="value"
+            :is-active="active"
+            :title="t('common.mine')"
+          />
         </Step>
-        <Step v-tooltip.bottom="t('common.clean')" :value="3">
-          <span class="hidden md:block">
-            {{ $t('common.clean') }}
-          </span>
+        <Step v-slot="{ active, value }" as-child :value="3">
+          <StepWithTooltip
+            :step-number="value"
+            :is-active="active"
+            :title="t('common.clean')"
+          />
         </Step>
-        <Step v-tooltip.bottom="t('common.enrich')" :value="4">
-          <span class="hidden md:block">
-            {{ $t('common.enrich') }}
-          </span>
+        <Step v-slot="{ active, value }" as-child :value="4">
+          <StepWithTooltip
+            :step-number="value"
+            :is-active="active"
+            :title="t('common.enrich')"
+          />
         </Step>
       </StepList>
       <StepPanels>
-        <StepPanel v-if="$stepper.index === 1" :value="1">
-          <SourcePanel ref="sourcePanel" />
+        <StepPanel v-slot="{ active }" :value="1">
+          <SourcePanel v-if="active" ref="sourcePanel" />
         </StepPanel>
-        <StepPanel v-if="$stepper.index === 2" :value="2">
-          <MinePanel :mining-source="$leadminerStore.activeMiningSource!" />
+        <StepPanel v-slot="{ active }" :value="2">
+          <MinePanel
+            v-if="active"
+            :mining-source="$leadminerStore.activeMiningSource!"
+          />
         </StepPanel>
-        <StepPanel v-if="$stepper.index === 3" :value="3">
-          <CleanPanel />
+        <StepPanel v-slot="{ active }" :value="3">
+          <CleanPanel v-if="active" />
         </StepPanel>
-        <StepPanel v-if="$stepper.index === 4" :value="4">
-          <EnrichPanel />
+        <StepPanel v-slot="{ active }" :value="4">
+          <EnrichPanel v-if="active" />
         </StepPanel>
       </StepPanels>
     </Stepper>
@@ -76,6 +87,10 @@ const CleanPanel = defineAsyncComponent(
 );
 const EnrichPanel = defineAsyncComponent(
   () => import('./StepperPanels/EnrichPanel.vue'),
+);
+
+const StepWithTooltip = defineAsyncComponent(
+  () => import('./StepperPanels/StepWithPopover.vue'),
 );
 
 const { t } = useI18n({

--- a/frontend/src/components/Mining/StepperPanels/StepWithPopover.vue
+++ b/frontend/src/components/Mining/StepperPanels/StepWithPopover.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="p-step" @click="toggle">
+    <div :class="`${isActive ? 'p-step-active' : 'p-disabled'}`">
+      <button class="p-step-header">
+        <span class="p-step-number">{{ stepNumber }}</span>
+        <span class="p-step-title hidden md:block"> {{ title }} </span>
+      </button>
+    </div>
+    <span class="p-stepper-separator" />
+  </div>
+  <Popover ref="titlePopover" class="block md:hidden">
+    {{ title }}
+  </Popover>
+</template>
+
+<script lang="ts" setup>
+const { stepNumber, isActive, title } = defineProps<{
+  stepNumber: string | number;
+  isActive: boolean;
+  title: string;
+}>();
+
+const titlePopover = ref();
+const toggle = (event: MouseEvent) => {
+  titlePopover.value.toggle(event);
+};
+</script>
+
+<style scoped>
+.p-step:has(~ .p-step .p-step-active) .p-stepper-separator {
+  background: var(--p-stepper-separator-active-background);
+}
+</style>


### PR DESCRIPTION
- resolves #1676
- use Popover instead of tooltip (as there is no hover in mobile)
![image](https://github.com/user-attachments/assets/c784186a-40fc-4b67-a4f3-9219fa393f4e)
![image](https://github.com/user-attachments/assets/5604bfa5-914f-4335-aaec-5f18c74d3380)
