### PR TITLE
Disable ci-check run on github action  changes

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,15 +24,6 @@ jobs:
               - 'backend/**'
             frontend:
               - 'frontend/**'
-      - uses: actions/checkout@v4
-      - name: Create empty coverage report
-        run: touch ./lcov.info
-      - name: Report code coverage to Deepsource
-        run: |
-          curl https://deepsource.io/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key javascript --value-file ./lcov.info
-        env:
-          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
 
   backend:
     needs: changes


### PR DESCRIPTION
#1532 
- [x] Disable Ci-checks on github action workflow changes
- [x] Start with unit test before other steps (Formatting step often fail and the workflow exits before calculating and delivering code coverage)
- [x] Report empty code coverage for frontend