### PR TITLE
auto merge Snyk PRs

### DIFF
--- a/.github/workflows/auto-merge-snyk-pr.yml
+++ b/.github/workflows/auto-merge-snyk-pr.yml
@@ -32,6 +32,18 @@ jobs:
           echo "Found PR number: $pr_number"
           echo "pr_number=$pr_number" >> "$GITHUB_ENV"
 
+      - name: Check for Merge Conflicts
+        run: |
+          # Check mergeability status using GitHub CLI
+          sleep 10
+          pr_mergeable=$(gh pr view "$pr_number" --json mergeable -q '.mergeable')
+          if [[ "$pr_mergeable" == "MERGEABLE" ]]; then
+            echo "The PR can be merged."
+          else
+            echo "The PR can't be merged."
+            exit 1
+          fi
+
       # Merge the pull request
       - name: Auto Merge Snyk PR
         uses: "pascalgn/automerge-action@v0.16.4"


### PR DESCRIPTION
https://github.com/ankaboot-source/leadminer.io/issues/517

This action will be triggered when there is a new branch name starting with **snyk...** is created.

Since PRs are automaticaly opened by snyk then this part is skipped from this action and we check for the **pr_number** related to the branch that triggered this action (with `--head github.ref_name`).

In case **pr_number** is empty the workflow will exit, in case it's not then last step will be merging that specific PR.