### PR TITLE
Fix navbar's "Start mining" is not resetting the stepper appropriately

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -69,7 +69,7 @@
               type="button"
               :label="$t('common.start_mining')"
               @click="
-                navigateTo(minePath);
+                navigateToMine();
                 closeCallback();
               "
             />
@@ -121,7 +121,7 @@ function navigateToMine() {
     $leadminerStore.miningStartedAndFinished ||
     $router.currentRoute.value.path === minePath
   ) {
-    $stepper.$reset();
+    $stepper.go(1);
     $leadminerStore.$resetMining();
     $sourcePanelStore.hideOtherSources();
   }


### PR DESCRIPTION
- fixes #2109 :
  - not calling the right function on mobile's navbar
  - regression as `$stepper.$reset()` used to go to step 1