### PR TITLE
add quickfilter: "phone"

### DIFF
--- a/frontend/src/components/Mining/Table/MiningTable.vue
+++ b/frontend/src/components/Mining/Table/MiningTable.vue
@@ -177,6 +177,16 @@
                   @update:model-value="filtersStore.onRepliesToggle"
                 />
               </li>
+              <li class="flex justify-between gap-2">
+                <div>
+                  {{ t('toggle_phone_label') }}
+                </div>
+                <ToggleSwitch
+                  v-model="filtersStore.phoneToggle"
+                  @update:model-value="filtersStore.onPhoneToggle"
+                />
+              </li>
+
               <Divider class="my-0" />
               <MultiSelect
                 v-model="visibleColumns"
@@ -605,9 +615,6 @@
         <div v-tooltip.top="$t('contact.telephone_definition')">
           {{ $t('contact.telephone') }}
         </div>
-      </template>
-      <template #filter="{ filterModel }">
-        <InputText v-model="filterModel.value" />
       </template>
       <template #body="{ data }">
         <div class="flex flex-wrap gap-1">
@@ -1154,6 +1161,7 @@ table.p-datatable-table {
     "toggle_valid_label": "Only valid contacts",
     "toggle_replies_tooltip": "Contacts who previously engaged with you perform best",
     "toggle_replies_label": "At least one reply",
+    "toggle_phone_label": "Only with phone number",
     "toggle_name_label": "Only with name",
     "toggle_name_tooltip": "Named contacts engage more",
     "toggle_recent_tooltip": "- Less than {recentYearsAgo} years \n- GDPR Proof",
@@ -1202,6 +1210,7 @@ table.p-datatable-table {
     "toggle_valid_label": "Seulement les contacts valides",
     "toggle_replies_tooltip": "Les contacts qui ont déjà interagi avec vous ont les meilleures performances",
     "toggle_replies_label": "Au moins une réponse",
+    "toggle_phone_label": "Seulement avec un numéro de téléphone",
     "toggle_name_label": "Seulement avec un nom complet",
     "toggle_name_tooltip": "Les contacts connus par leur nom complet répondent davantage",
     "toggle_recent_tooltip": "- Moins de {recentYearsAgo} ans \n- Conforme au RGPD",

--- a/frontend/src/stores/filters.ts
+++ b/frontend/src/stores/filters.ts
@@ -2,9 +2,9 @@ import { FilterService } from '@primevue/core/api';
 import { useDebounceFn } from '@vueuse/core';
 import { defineStore } from 'pinia';
 import {
-  DEFAULT_TOGGLES,
-  DEFAULT_FILTERS,
   ANY_SELECTED,
+  DEFAULT_FILTERS,
+  DEFAULT_TOGGLES,
   MAX_YEARS_AGO_TO_FILTER,
   NOT_EMPTY,
 } from '~/utils/filters-defaults';
@@ -14,6 +14,7 @@ type TogglesType = {
   recent: boolean;
   name: boolean;
   replies: boolean;
+  telephone: boolean;
 };
 
 const searchContactModel = ref('');
@@ -22,6 +23,7 @@ const nameToggle = ref(false);
 const validToggle = ref(false);
 const repliesToggle = ref(false);
 const recentToggle = ref(false);
+const phoneToggle = ref(false);
 
 const isDefaultFilters = computed(
   () => JSON.stringify(filters.value) === JSON.stringify(DEFAULT_FILTERS),
@@ -31,7 +33,8 @@ const areToggledFilters = computed(
     Number(validToggle.value) +
     Number(recentToggle.value) +
     Number(nameToggle.value) +
-    Number(repliesToggle.value),
+    Number(repliesToggle.value) +
+    Number(phoneToggle.value),
 );
 
 function checkValidStatus() {
@@ -89,6 +92,13 @@ function onRecentToggle(toggle?: boolean) {
     : null;
 }
 
+function onPhoneToggle(toggle?: boolean) {
+  if (toggle !== undefined) {
+    phoneToggle.value = toggle;
+    filters.value.telephone.value = toggle || null;
+  }
+}
+
 function onNameToggle(toggle?: boolean) {
   if (toggle !== undefined) {
     nameToggle.value = toggle;
@@ -139,10 +149,8 @@ function registerFiltersAndStartWatchers() {
   FilterService.register(ANY_SELECTED, (value, filter) =>
     !filter ? true : filter.some((item: string) => value.includes(item)),
   );
-  FilterService.register(NOT_EMPTY, (value) =>
-    nameToggle.value
-      ? !(value === undefined || value === null || value === '')
-      : true,
+  FilterService.register(NOT_EMPTY, (value, filter) =>
+    filter ? !(value === undefined || value === null || value === '') : true,
   );
 
   const debouncedUpdate = useDebounceFn((newValue: string) => {
@@ -165,6 +173,7 @@ function toggleFilters(toggles: TogglesType | boolean = DEFAULT_TOGGLES) {
       recent: toggles,
       name: toggles,
       replies: toggles,
+      telephone: toggles,
     };
   }
 
@@ -172,6 +181,7 @@ function toggleFilters(toggles: TogglesType | boolean = DEFAULT_TOGGLES) {
   onValidToggle(toggles.valid);
   onRecentToggle(toggles.recent);
   onRepliesToggle(toggles.replies);
+  onPhoneToggle(toggles.telephone);
 }
 
 function clearFilter() {
@@ -195,6 +205,7 @@ export const useFiltersStore = defineStore('filters', () => {
     validToggle,
     repliesToggle,
     recentToggle,
+    phoneToggle,
 
     areToggledFilters,
     isDefaultFilters,
@@ -203,6 +214,7 @@ export const useFiltersStore = defineStore('filters', () => {
     onRepliesToggle,
     onRecentToggle,
     onNameToggle,
+    onPhoneToggle,
 
     toggleFilters,
     clearFilter,

--- a/frontend/src/utils/filters-defaults.ts
+++ b/frontend/src/utils/filters-defaults.ts
@@ -1,4 +1,4 @@
-import { FilterOperator, FilterMatchMode } from '@primevue/core';
+import { FilterMatchMode, FilterOperator } from '@primevue/core';
 
 // Filter configuration helpers
 function createConstraint(matchMode: string, value: unknown = null) {
@@ -25,11 +25,13 @@ export const DEFAULT_TOGGLES = {
   recent: false,
   name: false,
   replies: false,
+  telephone: false,
 };
 
 export const DEFAULT_FILTERS = {
   global: { value: null, matchMode: FilterMatchMode.CONTAINS },
   name: { value: null, matchMode: NOT_EMPTY },
+  telephone: { value: null, matchMode: NOT_EMPTY },
   tags: { value: null, matchMode: ANY_SELECTED },
   status: { value: [], matchMode: FilterMatchMode.IN },
   ...Object.fromEntries(
@@ -38,7 +40,6 @@ export const DEFAULT_FILTERS = {
       'given_name',
       'family_name',
       'alternate_name',
-      'telephone',
       'location',
       'works_for',
       'job_title',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f05ae545-4d20-453a-a669-f562cf2efba1)

-  Cannot filter out `null` values using `FilterMatchMode.CONTAINS`, so it was removed in favor of custom `NOT_EMPTY`, i will see if i could extend that default filter to have that functionality
- partially resolves #2307