### PR TITLE
fix progress time not updating despite active progress

### DIFF
--- a/frontend/src/components/Mining/StepperPanels/CleanPanel.vue
+++ b/frontend/src/components/Mining/StepperPanels/CleanPanel.vue
@@ -2,6 +2,7 @@
   <ProgressCard
     :status="$leadminerStore.activeTask"
     :total="contactsToVerify"
+    :current="verifiedContacts"
     :rate="3"
     :started="taskStartedAt"
     :progress="verificationProgress"
@@ -31,9 +32,9 @@
   <component :is="AcceptNewsLetter" v-if="verificationFinished" type="dialog" />
 </template>
 <script setup lang="ts">
-import { AcceptNewsLetter } from '~/utils/extras';
-import { FetchError } from 'ofetch';
 import ProgressCard from '@/components/ProgressCard.vue';
+import { FetchError } from 'ofetch';
+import { AcceptNewsLetter } from '~/utils/extras';
 
 const { t } = useI18n({
   useScope: 'local',

--- a/frontend/src/components/Mining/StepperPanels/MinePanel.vue
+++ b/frontend/src/components/Mining/StepperPanels/MinePanel.vue
@@ -3,6 +3,7 @@
     v-if="boxes"
     :status="$leadminerStore.activeMiningTask"
     :total="totalEmails"
+    :current="extractedEmails"
     :rate="AVERAGE_EXTRACTION_RATE"
     :started="taskStartedAt"
     :progress="extractionProgress"

--- a/frontend/src/components/ProgressCard.vue
+++ b/frontend/src/components/ProgressCard.vue
@@ -36,10 +36,15 @@ const { t } = useI18n({
   useScope: 'local',
 });
 
+const MIN_PROGRESS_FOR_ESTIMATION = 0.05; // wait 5% progress for estimation
+const MIN_ELAPSED_FOR_ESTIMATION = 5 * 1000; // wait 5 seconds for estimation
+const SUFFICIENT_ITEMS_FOR_ESTIMATION = 100; // estimate right away if >=100 items treated
+
 const props = defineProps({
   status: { type: Boolean, required: true },
   rate: { type: Number, required: true },
   total: { type: Number, default: 0 },
+  current: { type: Number, default: 0 },
   progress: { type: Number, default: 0 },
   started: { type: Number, default: 0 },
   // skipcq: JS-0715 - Is used in the template
@@ -72,7 +77,11 @@ watchEffect(() => {
 function getEstimatedRemainingTime() {
   const elapsedTime = getElapsedTime();
 
-  if (props.progress < 0.01 || elapsedTime === 0) {
+  if (
+    props.current < SUFFICIENT_ITEMS_FOR_ESTIMATION &&
+    (props.progress < MIN_PROGRESS_FOR_ESTIMATION ||
+      elapsedTime < MIN_ELAPSED_FOR_ESTIMATION)
+  ) {
     return Math.round(props.total / props.rate);
   }
 


### PR DESCRIPTION
progress estimation was starting after 10% of progress
- adds `current` prop for ProgressCard.vue
- wait (5% progress &&  5 seconds) for estimation
- estimate right away if >=100 items treated
- fix estimated_time message