### PR TITLE
refine_persons(): Keep persons where at least one tag is reachable

### DIFF
--- a/supabase/migrations/20251119151502_refine_persons_fix_tags_filter.sql
+++ b/supabase/migrations/20251119151502_refine_persons_fix_tags_filter.sql
@@ -1,3 +1,4 @@
+-- Keep only persons where at least one tag is reachable (Not 3) --
 CREATE OR REPLACE FUNCTION private.refine_persons(userid uuid)
 RETURNS void
 LANGUAGE plpgsql


### PR DESCRIPTION
- refine_persons(): Keep persons where at least one tag is reachable (not `3`)
- resolves #2519 