### PR TITLE
fix pst-extractor import path

### DIFF
--- a/micro-services/emails-fetcher/src/services/pst/PSTEmailsFetcher.ts
+++ b/micro-services/emails-fetcher/src/services/pst/PSTEmailsFetcher.ts
@@ -5,7 +5,7 @@ import {
   PSTFile,
   PSTFolder,
   PSTMessage
-} from '../../../../pst-extractor-feat-support-slblock-entry/src';
+} from 'pst-extractor';
 import ENV from '../../config';
 import { getMessageId } from '../../utils/helpers/emailHeaderHelpers';
 import hashEmail from '../../utils/helpers/hashHelpers';


### PR DESCRIPTION
remove testing leftover import 'pst-extractor-feat-support-slblock-entry', not sure how QA pst minings worked despite having wrong import path 😅