### PR TITLE
fix mine panel state is not reset on pst mine

### DIFF
--- a/frontend/src/components/Mining/StepperPanels/SourcePanel.vue
+++ b/frontend/src/components/Mining/StepperPanels/SourcePanel.vue
@@ -117,8 +117,7 @@ const sourceModel = ref<MiningSource | undefined>(sourceOptions?.value[0]);
 
 function extractContacts(miningSource?: MiningSource) {
   if (miningSource) {
-    $leadminerStore.boxes = [];
-    $leadminerStore.selectedBoxes = [];
+    $leadminerStore.$resetMining();
     $leadminerStore.activeMiningSource = miningSource;
     $stepper.next();
   }

--- a/frontend/src/stores/leadminer.ts
+++ b/frontend/src/stores/leadminer.ts
@@ -104,6 +104,8 @@ export const useLeadminerStore = defineStore('leadminer', () => {
 
     miningInterrupted.value = false;
 
+    miningType.value = 'email';
+
     errors.value = {};
   }
 


### PR DESCRIPTION
- fix #2586 
- `resetMining()` on source's `extractContacts()`, resets `miningType`