### PR TITLE
fix: prevent campaign terminal toasts from replaying on tab revisit

### DIFF
--- a/frontend/src/pages/campaigns.vue
+++ b/frontend/src/pages/campaigns.vue
@@ -208,10 +208,6 @@ const $campaignsStore = useCampaignsStore();
 const { t } = useI18n({ useScope: 'local' });
 const { $saasEdgeFunctions } = useNuxtApp();
 const $toast = useToast();
-const terminalToasts = useState<Record<string, boolean>>(
-  'campaign-terminal-toasts',
-  () => ({}),
-);
 type CampaignActionType = 'stop' | 'delete';
 const actionDialogVisible = ref(false);
 const actionDialogCampaign = ref<CampaignOverview | null>(null);
@@ -360,16 +356,10 @@ async function confirmActionDialog() {
 }
 
 function notifyTerminalCampaigns() {
-  $campaignsStore.campaigns.forEach((campaign) => {
-    if (campaign.status !== 'completed' && campaign.status !== 'failed') {
-      return;
-    }
+  const campaignsToNotify =
+    $campaignsStore.consumeTerminalCampaignNotifications();
 
-    const toastKey = `${campaign.id}:${campaign.status}`;
-    if (terminalToasts.value[toastKey]) return;
-
-    terminalToasts.value[toastKey] = true;
-
+  campaignsToNotify.forEach((campaign) => {
     if (campaign.status === 'failed') {
       $toast.add({
         group: 'has-links',

--- a/frontend/src/tests/unit/campaign-terminal-toast.test.ts
+++ b/frontend/src/tests/unit/campaign-terminal-toast.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { computeTerminalCampaignNotifications } from '@/utils/campaignTerminalToasts';
+import type { CampaignOverview } from '@/types/campaign';
+
+function makeCampaign(
+  id: string,
+  status: CampaignOverview['status'],
+): CampaignOverview {
+  return {
+    id,
+    sender_name: 'sender',
+    sender_email: 'sender@example.com',
+    subject: 'subject',
+    status,
+    total_recipients: 1,
+    attempted: 1,
+    delivered: 1,
+    hard_bounced: 0,
+    soft_bounced: 0,
+    failed_other: 0,
+    opened: 0,
+    clicked: 0,
+    unsubscribed: 0,
+    delivery_rate: 100,
+    opening_rate: 0,
+    clicking_rate: 0,
+    unsubscribe_rate: 0,
+    track_open: true,
+    track_click: true,
+    link_clicks: [],
+    created_at: new Date().toISOString(),
+    started_at: null,
+    completed_at: null,
+  };
+}
+
+describe('computeTerminalCampaignNotifications', () => {
+  it('does not emit toasts for the first observed snapshot', () => {
+    const firstSnapshot = [makeCampaign('c1', 'completed')];
+
+    const result = computeTerminalCampaignNotifications({}, firstSnapshot);
+
+    expect(result.notifications).toHaveLength(0);
+    expect(result.statusesByCampaignId.c1).toBe('completed');
+  });
+
+  it('emits once when campaign transitions to completed', () => {
+    const previousStatuses = { c1: 'processing' as const };
+    const nextSnapshot = [makeCampaign('c1', 'completed')];
+
+    const result = computeTerminalCampaignNotifications(
+      previousStatuses,
+      nextSnapshot,
+    );
+
+    expect(result.notifications).toHaveLength(1);
+    expect(result.notifications[0].id).toBe('c1');
+  });
+
+  it('does not emit repeatedly for unchanged terminal status', () => {
+    const previousStatuses = { c1: 'completed' as const };
+    const nextSnapshot = [makeCampaign('c1', 'completed')];
+
+    const result = computeTerminalCampaignNotifications(
+      previousStatuses,
+      nextSnapshot,
+    );
+
+    expect(result.notifications).toHaveLength(0);
+  });
+});

--- a/frontend/src/utils/campaignTerminalToasts.ts
+++ b/frontend/src/utils/campaignTerminalToasts.ts
@@ -1,0 +1,41 @@
+import type { CampaignOverview, CampaignStatus } from '@/types/campaign';
+
+export type CampaignStatusesById = Record<string, CampaignStatus>;
+
+function isTerminalStatus(status: CampaignStatus) {
+  return status === 'completed' || status === 'failed';
+}
+
+export function computeTerminalCampaignNotifications(
+  previousStatusesByCampaignId: CampaignStatusesById,
+  campaigns: CampaignOverview[],
+) {
+  const notifications: CampaignOverview[] = [];
+  const statusesByCampaignId: CampaignStatusesById = {};
+
+  campaigns.forEach((campaign) => {
+    const previousStatus = previousStatusesByCampaignId[campaign.id];
+    const currentStatus = campaign.status;
+
+    statusesByCampaignId[campaign.id] = currentStatus;
+
+    if (!previousStatus) {
+      return;
+    }
+
+    if (previousStatus === currentStatus) {
+      return;
+    }
+
+    if (!isTerminalStatus(currentStatus)) {
+      return;
+    }
+
+    notifications.push(campaign);
+  });
+
+  return {
+    notifications,
+    statusesByCampaignId,
+  };
+}


### PR DESCRIPTION
## Summary
- move terminal toast detection to campaigns store state instead of page-local state
- emit terminal toasts only when a campaign status transitions into `completed` or `failed`
- consume queued notifications from store in campaigns page so revisiting `/campaigns` does not replay old toasts

## Verification
- Ran `npm test -- src/tests/unit/campaign-terminal-toast.test.ts` in `frontend/`
- Added unit tests for first snapshot behavior, terminal transition behavior, and no-repeat behavior