### PR TITLE
feat: continuous mining toggle action, reconnect flow, and status badges

### DIFF
--- a/frontend/src/tests/unit/source-status-badge.test.ts
+++ b/frontend/src/tests/unit/source-status-badge.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSourceStatusBadge } from '@/utils/sourceStatusBadge';
+
+describe('resolveSourceStatusBadge', () => {
+  it('returns mining status badge as info when source is currently mining', () => {
+    const badge = resolveSourceStatusBadge({
+      isValid: true,
+      isActiveMiningSource: true,
+      miningStatus: 'running',
+    });
+
+    expect(badge.labelKey).toBe('mining_status_running');
+    expect(badge.severity).toBe('info');
+    expect(badge.icon).toBeUndefined();
+  });
+
+  it('returns connected status when source is valid and not currently mining', () => {
+    const badge = resolveSourceStatusBadge({
+      isValid: true,
+      isActiveMiningSource: false,
+      miningStatus: undefined,
+    });
+
+    expect(badge.labelKey).toBe('connected');
+    expect(badge.severity).toBe('success');
+  });
+
+  it('returns expired status with warning icon when credentials are invalid', () => {
+    const badge = resolveSourceStatusBadge({
+      isValid: false,
+      isActiveMiningSource: false,
+      miningStatus: undefined,
+    });
+
+    expect(badge.labelKey).toBe('credential_expired');
+    expect(badge.severity).toBe('warn');
+    expect(badge.icon).toBe('pi pi-exclamation-triangle');
+  });
+});

--- a/frontend/src/utils/sourceStatusBadge.ts
+++ b/frontend/src/utils/sourceStatusBadge.ts
@@ -1,0 +1,62 @@
+import type { MiningTask } from '~/types/mining';
+
+type SourceStatusLabelKey =
+  | 'connected'
+  | 'credential_expired'
+  | 'mining_status_running'
+  | 'mining_status_done'
+  | 'mining_status_canceled'
+  | 'mining_in_progress';
+
+export interface SourceStatusBadge {
+  labelKey: SourceStatusLabelKey;
+  severity: 'success' | 'warn' | 'info';
+  icon?: string;
+}
+
+interface ResolveSourceStatusBadgeInput {
+  isValid: boolean;
+  isActiveMiningSource: boolean;
+  miningStatus?: MiningTask['status'];
+}
+
+export function resolveSourceStatusBadge(
+  input: ResolveSourceStatusBadgeInput,
+): SourceStatusBadge {
+  if (!input.isValid) {
+    return {
+      labelKey: 'credential_expired',
+      severity: 'warn',
+      icon: 'pi pi-exclamation-triangle',
+    };
+  }
+
+  if (input.isActiveMiningSource) {
+    if (input.miningStatus === 'done') {
+      return {
+        labelKey: 'mining_status_done',
+        severity: 'info',
+      };
+    }
+
+    if (input.miningStatus === 'canceled') {
+      return {
+        labelKey: 'mining_status_canceled',
+        severity: 'info',
+      };
+    }
+
+    return {
+      labelKey:
+        input.miningStatus === 'running'
+          ? 'mining_status_running'
+          : 'mining_in_progress',
+      severity: 'info',
+    };
+  }
+
+  return {
+    labelKey: 'connected',
+    severity: 'success',
+  };
+}


### PR DESCRIPTION
## Summary
- continuous mining toggle now starts mining immediately when enabled (not just saving the flag)
- click on expired credential badge triggers OAuth reconnect flow (google/azure)
- status badge shows mining status in blue when source is actively mining
- status badge shows warning icon for expired credentials
- connected status stays green when valid (even if continuous mining enabled but idle)
- also includes: card title uses email only, contacts (total) label, french wording fixes (supprimer + accents)

## Verification
- `npm test -- src/tests/unit/source-status-badge.test.ts` (3 passing)
- `npm run lint -- src/pages/sources.vue src/utils/sourceStatusBadge.ts src/tests/unit/source-status-badge.test.ts` (0 errors)