### PR TITLE
fix(campaigns): improve error messages for OAuth issues

### DIFF
--- a/supabase/functions/email-campaigns/sender-options.ts
+++ b/supabase/functions/email-campaigns/sender-options.ts
@@ -171,7 +171,7 @@ export function getSenderCredentialIssue(
 
   const expiresAt = Number(source.credentials.expiresAt);
   if (Number.isFinite(expiresAt) && expiresAt > 0 && expiresAt <= nowMs) {
-    return "OAuth token expired. Reconnect this source.";
+    return "Token OAuth expiré. Veuillez reconnecter ce compte dans les sources.";
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Add getUserFriendlyError function to detect and clarify credential errors
- Show clear French message for 535/credential errors: 'Identifiants OAuth invalides ou token expiré'
- Show helpful messages for connection/timeout and rate limiting errors
- Update expired token message to French for consistency

## Test Plan
- [ ] Test with OAuth sender - should see clearer error messages
- [ ] Check logs for OAuth debug messages