### PR TITLE
fix: disable tracking checkboxes when plain text only is selected

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -234,7 +234,12 @@
           </div>
 
           <div class="flex items-center gap-2">
-            <Checkbox v-model="form.trackOpen" binary input-id="track-open" />
+            <Checkbox
+              v-model="form.trackOpen"
+              binary
+              input-id="track-open"
+              :disabled="form.plainTextOnly"
+            />
             <label for="track-open">{{ t('track_open') }}</label>
             <i
               v-tooltip.top="t('track_open_help')"
@@ -259,28 +264,6 @@
                 form.plainTextOnly
                   ? t('track_disabled_plain_text')
                   : t('track_click_help')
-              "
-              class="pi pi-info-circle text-xs text-surface-500"
-            />
-          </div>
-
-          <div class="flex items-center gap-2 md:col-span-2">
-            <Checkbox
-              v-model="form.trackOpen"
-              binary
-              input-id="track-open"
-              :disabled="form.plainTextOnly"
-            />
-            <label
-              for="track-open"
-              :class="{ 'opacity-50': form.plainTextOnly }"
-              >{{ t('track_open') }}</label
-            >
-            <i
-              v-tooltip.top="
-                form.plainTextOnly
-                  ? t('track_disabled_plain_text')
-                  : t('track_open_help')
               "
               class="pi pi-info-circle text-xs text-surface-500"
             />


### PR DESCRIPTION
## Summary

- Add `:disabled` on trackOpen checkbox when plainTextOnly is checked
- Remove duplicate trackOpen checkbox that was using `md:col-span-2`
- TrackOpen and TrackClick are now properly disabled when plain text mode is selected
- Existing watcher already unchecks them, now they are also visually disabled

## Changes

- `frontend/src/components/campaigns/CampaignComposerDialog.vue`:
  - Added `:disabled="form.plainTextOnly"` to trackOpen checkbox
  - Removed duplicate trackOpen checkbox (was causing confusion with 2 checkboxes)
  - Both trackOpen and trackClick are now properly disabled when plain text is selected