### PR TITLE
fix(campaigns): refactor token expiration check and fix schema issue

### DIFF
--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -11,6 +11,7 @@ import { resolveCampaignBaseUrlFromEnv } from "../_shared/url.ts";
 import { sendEmail, verifyTransport } from "./email.ts";
 import {
   getSenderCredentialIssue,
+  isTokenExpired,
   listUniqueSenderSources,
   refreshOAuthToken,
   updateMiningSourceCredentials,
@@ -662,19 +663,15 @@ async function resolveSenderOptions(authorization: string, userEmail: string) {
   }
 
   for (const source of sources) {
-    const expiresAt = source.credentials.expiresAt;
     const nowMs = Date.now();
+    const expired = isTokenExpired(source.credentials, nowMs);
     console.log(
       "[OAuth] Checking source:",
       source.email,
       "- type:",
       source.type,
-      "- expiresAt:",
-      expiresAt,
-      "- now:",
-      nowMs,
       "- isExpired:",
-      expiresAt && expiresAt <= nowMs,
+      expired,
     );
 
     const credentialIssue = getSenderCredentialIssue(source);


### PR DESCRIPTION
Summary:
- Add shared isTokenExpired() function in sender-options.ts
- Modify getSenderCredentialIssue to use isTokenExpired
- Use isTokenExpired in index.ts instead of manual comparison
- Fix updateMiningSourceCredentials to use .schema('private')