### PR TITLE
fix(campaigns): use LEADMINER_API_HASH_SECRET instead of LEADMINER_HASH_SECRET

### DIFF
--- a/supabase/functions/.env.dev
+++ b/supabase/functions/.env.dev
@@ -1,5 +1,5 @@
 LEADMINER_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-LEADMINER_HASH_SECRET=change_me
+LEADMINER_API_HASH_SECRET=change_me
 SUPABASE_PROJECT_URL=http://host.docker.internal:54321/  # Required for self-hosted/prod: Your public Supabase URL (e.g., https://db.yourdomain.com)
 LEADMINER_SECRET_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
 

--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -24,7 +24,9 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") as string;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get(
   "SUPABASE_SERVICE_ROLE_KEY",
 ) as string;
-const LEADMINER_HASH_SECRET = Deno.env.get("LEADMINER_HASH_SECRET") as string;
+const LEADMINER_API_HASH_SECRET = Deno.env.get(
+  "LEADMINER_API_HASH_SECRET",
+) as string;
 const CAMPAIGN_COMPLIANCE_FOOTER = (
   Deno.env.get("campaign_compliance_footer") ||
   Deno.env.get("CAMPAIGN_COMPLIANCE_FOOTER") ||
@@ -519,7 +521,7 @@ async function getUserMiningSources(authorization: string) {
   const { data, error } = await supabase
     .schema("private")
     .rpc("get_user_mining_source_credentials", {
-      _encryption_key: LEADMINER_HASH_SECRET,
+      _encryption_key: LEADMINER_API_HASH_SECRET,
     });
 
   if (error) {
@@ -1652,7 +1654,7 @@ app.post(
           .schema("private")
           .rpc("get_mining_source_credentials_for_user", {
             _user_id: campaign.user_id,
-            _encryption_key: LEADMINER_HASH_SECRET,
+            _encryption_key: LEADMINER_API_HASH_SECRET,
           });
 
         if (error) {


### PR DESCRIPTION
The backend uses LEADMINER_API_HASH_SECRET to encrypt credentials. Edge functions were using LEADMINER_HASH_SECRET which was different, causing 'Wrong key or corrupt data' errors when decrypting.