### PR TITLE
fix: unsubscribe link in email campaign preview

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -159,7 +159,7 @@ export default defineNuxtConfig({
         '/campaigns',
         '/account(/*)?',
       ],
-      exclude: ['/auth(/*)?', '/credits-success'],
+      exclude: ['/auth(/*)?', '/credits-success', '/unsubscribe(/*)?'],
     },
   },
 

--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -36,7 +36,7 @@ const PUBLIC_CAMPAIGN_BASE_URL = resolveCampaignBaseUrlFromEnv((key) =>
   Deno.env.get(key),
 );
 const SMTP_USER = normalizeEmail(Deno.env.get("SMTP_USER") || "");
-const LEADMINER_FRONTEND_HOST = Deno.env.get("LEADMINER_FRONTEND_HOST") || "";
+const FRONTEND_HOST = Deno.env.get("FRONTEND_HOST") || "";
 const DEFAULT_SENDER_DAILY_LIMIT = 1000;
 const MAX_SENDER_DAILY_LIMIT = 2000;
 const PROCESSING_BATCH_SIZE = 300;
@@ -1989,7 +1989,7 @@ app.get("/unsubscribe/:token", async (c: Context) => {
       status: 302,
       headers: {
         ...corsHeaders,
-        Location: `${LEADMINER_FRONTEND_HOST}/unsubscribe/success?preview=true`,
+        Location: `${FRONTEND_HOST}/unsubscribe/success?preview=true`,
       },
     });
   }
@@ -2006,7 +2006,7 @@ app.get("/unsubscribe/:token", async (c: Context) => {
       status: 302,
       headers: {
         ...corsHeaders,
-        Location: `${LEADMINER_FRONTEND_HOST}/unsubscribe/failure`,
+        Location: `${FRONTEND_HOST}/unsubscribe/failure`,
       },
     });
   }
@@ -2039,7 +2039,7 @@ app.get("/unsubscribe/:token", async (c: Context) => {
     status: 302,
     headers: {
       ...corsHeaders,
-      Location: `${LEADMINER_FRONTEND_HOST}/unsubscribe/success`,
+      Location: `${FRONTEND_HOST}/unsubscribe/success`,
     },
   });
 });


### PR DESCRIPTION
## Summary
- Add `/unsubscribe/*` routes to Supabase auth exclude list in nuxt.config to allow unauthenticated access
- Unify `LEADMINER_FRONTEND_HOST` to `FRONTEND_HOST` in email-campaigns edge function to match other edge functions and backend