### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/backend/src/services/auth/types.ts
+++ b/backend/src/services/auth/types.ts
@@ -1,5 +1,3 @@
-import { SupabaseAuthClient } from '@supabase/supabase-js/dist/module/lib/SupabaseAuthClient';
-
 /**
  * Represents the authenticated user.
  */
@@ -63,8 +61,6 @@ export interface ProviderConfig {
   imapConfig: IMAPConfig;
   domains: string[];
 }
-
-export type AuthenticationClient = SupabaseAuthClient;
 
 /**
  * Represents an authentication resolver that provides methods for authentication operations.

--- a/backend/src/workers/email-signature/handler.ts
+++ b/backend/src/workers/email-signature/handler.ts
@@ -298,7 +298,10 @@ export class EmailSignatureHandler {
       const text = planer.extractFrom(body, 'text/plain');
       const originalMessage = CleanQuotedForwardedReplies(text);
       const parsed = new EmailReplyParser().read(originalMessage);
-      const sigFrag = parsed.fragments.filter((f) => f.isSignature()).pop();
+      const sigFrag = parsed
+        .getFragments()
+        .filter((f: { isSignature(): boolean }) => f.isSignature())
+        .pop();
 
       return (
         sigFrag?.getContent() ??


### PR DESCRIPTION
## Summary
- Fix broken SupabaseAuthClient import (non-existent internal module in @supabase/supabase-js)
- Use public `getFragments()` method instead of private `fragments` property in email-reply-parser
- Add inline type annotation for filter callback parameter to fix implicit any error