### PR TITLE
fix: resolve remaining merge conflict markers in fetch-mining-source

### DIFF
--- a/supabase/functions/fetch-mining-source/index.ts
+++ b/supabase/functions/fetch-mining-source/index.ts
@@ -210,12 +210,8 @@ Deno.serve(async (req: Request) => {
 
       Logger.info(`Token expired for ${source.email}, attempting refresh`);
 
-<<<<<<< HEAD
       const { access_token, refresh_token, expires_at } =
         await refreshAccessToken(source.credentials);
-=======
-      const {access_token, refresh_token, expires_at} = await refreshAccessToken(source.credentials);
->>>>>>> origin/main
 
       if (!access_token || !expires_at) {
         Logger.warn(`Failed to refresh token for ${source.email}`);


### PR DESCRIPTION
## Summary
- Resolve remaining merge conflict markers in supabase/functions/fetch-mining-source/index.ts

The file had unmerged conflict markers that were causing runtime errors.