### PR TITLE
fix: improve RPC error logging in fetch-mining-source

### DIFF
--- a/supabase/functions/fetch-mining-source/index.ts
+++ b/supabase/functions/fetch-mining-source/index.ts
@@ -148,7 +148,8 @@ Deno.serve(async (req: Request) => {
         });
 
       if (error) {
-        throw new Error("Failed to fetch mining sources");
+        Logger.error("RPC error in service mode", { error: error.message });
+        throw new Error(`Failed to fetch mining sources: ${error.message}`);
       }
       sources = (data ?? []) as MiningSource[];
     } else {
@@ -159,7 +160,8 @@ Deno.serve(async (req: Request) => {
         });
 
       if (error) {
-        throw new Error("Failed to fetch mining sources");
+        Logger.error("RPC error in user mode", { error: error.message });
+        throw new Error(`Failed to fetch mining sources: ${error.message}`);
       }
       sources = (data ?? []) as MiningSource[];
     }


### PR DESCRIPTION
This PR improves error logging in fetch-mining-source edge function to expose the actual RPC error message instead of generic 'Failed to fetch mining sources'. This will help debug the root cause of mining sources fetch failures.