### PR TITLE
fix: mark sources as disconnected when unsuitable for sending

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -345,6 +345,7 @@
 <script setup lang="ts">
 import type { Contact } from '@/types/contact';
 import { extractUnavailableSenderEmails } from '@/utils/senderOptions';
+import { updateMiningSourcesValidityFromUnavailable } from '@/utils/sources';
 import Editor from 'primevue/editor';
 
 const isVisible = defineModel<boolean>('visible', { required: true });
@@ -357,6 +358,7 @@ const { t } = useI18n({ useScope: 'local' });
 const { t: globalT } = useI18n({ useScope: 'global' });
 const { $saasEdgeFunctions } = useNuxtApp();
 const $screenStore = useScreenStore();
+const $leadminer = useLeadminerStore();
 const $toast = useToast();
 const $user = useSupabaseUser();
 
@@ -936,6 +938,11 @@ async function loadSenderOptions() {
         life: 6500,
       });
     }
+
+    $leadminer.miningSources = updateMiningSourcesValidityFromUnavailable(
+      $leadminer.miningSources,
+      unavailableEmails,
+    );
 
     senderOptions.value = allOptions
       .filter((option) => option.available)

--- a/frontend/src/utils/sources.ts
+++ b/frontend/src/utils/sources.ts
@@ -22,6 +22,20 @@ export function updateMiningSourcesValidity(
   return miningSources.map(updateValidity);
 }
 
+export function updateMiningSourcesValidityFromUnavailable(
+  miningSources: MiningSource[],
+  unavailableEmails: string[],
+) {
+  const unavailableSet = new Set(
+    unavailableEmails.map((email) => email.toLowerCase()),
+  );
+
+  return miningSources.map((source) => ({
+    ...source,
+    isValid: !unavailableSet.has(source.email.toLowerCase()),
+  }));
+}
+
 export async function getMiningSources(): Promise<MiningSource[]> {
   const supabase = useSupabaseClient();
   const user = useSupabaseUser();


### PR DESCRIPTION
## Summary
- When sender-options returns an email as unavailable, the mining source's `isValid` flag is now updated so the Sources page shows "Credential expired" instead of "Connected" and allows reconnection.
- This fixes the issue where sources showed as "connected" even when sender-options indicated they weren't suitable for sending.