### PR TITLE
fix: default sender daily limit to 500 in UI and stack toast CTA

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -38,41 +38,51 @@
         </p>
 
         <div class="p-toast-detail">
-          {{ (slotProps.message.detail as ToastHasLinksGroupDetail).message }}
-          <Button
+          <div>
+            {{ (slotProps.message.detail as ToastHasLinksGroupDetail).message }}
+          </div>
+          <div
             v-if="
               (slotProps.message.detail as ToastHasLinksGroupDetail).button
                 ?.action
             "
             class="mt-2"
-            size="small"
-            :label="
-              (slotProps.message.detail as ToastHasLinksGroupDetail).button
-                ?.text
-            "
-            @click="
-              (
-                slotProps.message.detail as ToastHasLinksGroupDetail
-              ).button?.action?.()
-            "
-          ></Button>
-          <Button
+          >
+            <Button
+              size="small"
+              :label="
+                (slotProps.message.detail as ToastHasLinksGroupDetail).button
+                  ?.text
+              "
+              @click="
+                (
+                  slotProps.message.detail as ToastHasLinksGroupDetail
+                ).button?.action?.()
+              "
+            ></Button>
+          </div>
+          <div
             v-else-if="
               (slotProps.message.detail as ToastHasLinksGroupDetail).link
             "
-            class="-ml-3"
-            size="small"
-            as="a"
-            variant="link"
-            :label="
-              (slotProps.message.detail as ToastHasLinksGroupDetail).link?.text
-            "
-            :href="
-              (slotProps.message.detail as ToastHasLinksGroupDetail).link?.url
-            "
-            target="_blank"
-            rel="noopener"
-          />
+            class="mt-2"
+          >
+            <Button
+              class="-ml-3"
+              size="small"
+              as="a"
+              variant="link"
+              :label="
+                (slotProps.message.detail as ToastHasLinksGroupDetail).link
+                  ?.text
+              "
+              :href="
+                (slotProps.message.detail as ToastHasLinksGroupDetail).link?.url
+              "
+              target="_blank"
+              rel="noopener"
+            />
+          </div>
         </div>
       </div>
     </template>

--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -440,6 +440,8 @@ const DEFAULT_FOOTER_TEXT = () =>
     unsubscribeToken: '{{unsubscribeUrl}}',
   });
 
+const DEFAULT_SENDER_DAILY_LIMIT_UI = 500;
+
 const form = reactive({
   senderName: '',
   senderEmail: '',
@@ -447,7 +449,7 @@ const form = reactive({
   bodyHtmlTemplate: DEFAULT_BODY_HTML(),
   bodyTextTemplate: DEFAULT_BODY_TEXT(),
   footerTextTemplate: DEFAULT_FOOTER_TEXT(),
-  senderDailyLimit: 1000,
+  senderDailyLimit: DEFAULT_SENDER_DAILY_LIMIT_UI,
   trackOpen: true,
   trackClick: true,
   plainTextOnly: false,
@@ -917,7 +919,7 @@ async function loadSenderOptions() {
     );
 
     fallbackSenderEmail.value = data.fallbackSenderEmail || '';
-    form.senderDailyLimit = Number(data.defaultDailyLimit || 1000);
+    form.senderDailyLimit = DEFAULT_SENDER_DAILY_LIMIT_UI;
     const allOptions = (data.options || []).map(
       (option: { email: string; available: boolean }) => {
         return {


### PR DESCRIPTION
## Summary
- Keep the campaign sender daily limit default at 500 in the frontend composer
- Stop overriding the UI default from `sender-options.defaultDailyLimit`
- Render `has-links` toast CTA on a new line below the message text

## Notes
- This does **not** change allowed values; users can still submit 1000 (or any value within existing min/max)