### PR TITLE
fix: make passive cron migration idempotent

### DIFF
--- a/supabase/migrations/20260226142941_passive_mining_cron_job.sql
+++ b/supabase/migrations/20260226142941_passive_mining_cron_job.sql
@@ -26,8 +26,32 @@ BEGIN
 END;
 $$;
 
-SELECT cron.schedule(
-  'passive-cron-job',
-  '0 2 * * *', -- At 02:00 AM
-  $$ SELECT invoke_edge_function('passive-mining'); $$
-);
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'passive-cron-job'
+      AND schedule = '0 2 * * *'
+      AND regexp_replace(command, '\s+', ' ', 'g')
+        LIKE '%SELECT invoke_edge_function(''passive-mining'');%'
+  ) THEN
+    RAISE NOTICE 'passive-cron-job already configured, skipping';
+    RETURN;
+  END IF;
+
+  BEGIN
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'passive-cron-job';
+  EXCEPTION WHEN OTHERS THEN
+    DELETE FROM cron.job WHERE jobname = 'passive-cron-job';
+  END;
+
+  PERFORM cron.schedule(
+    'passive-cron-job',
+    '0 2 * * *', -- At 02:00 AM
+    $$ SELECT invoke_edge_function('passive-mining'); $$
+  );
+END
+$$;


### PR DESCRIPTION
## Summary
- make `passive-cron-job` scheduling idempotent in `20260226142941_passive_mining_cron_job.sql`
- skip scheduling when the existing cron job already matches the desired schedule and command
- add defensive cleanup (`cron.unschedule` with fallback delete) before re-scheduling when drift is detected

## Test Plan
- migration reviewed for safe reruns and cron state drift handling
- `npm run precommit:check` *(fails in this environment: `lint-staged: commande introuvable`)*