### PR TITLE
fix: harden passive cron reschedule in standardize migration

### DIFF
--- a/supabase/migrations/20260304160000_standardize_edge_function_invocation.sql
+++ b/supabase/migrations/20260304160000_standardize_edge_function_invocation.sql
@@ -83,14 +83,34 @@ SELECT cron.schedule(
 -- 4. Update passive mining cron job to use invoke_edge_function correctly
 -- ============================================================================
 
--- Unschedule the old cron job
-SELECT cron.unschedule('passive-cron-job');
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM cron.job
+        WHERE jobname = 'passive-cron-job'
+          AND schedule = '0 2 * * *'
+          AND regexp_replace(command, '\s+', ' ', 'g')
+            LIKE '%SELECT invoke_edge_function(''passive-mining'');%'
+    ) THEN
+        RAISE NOTICE 'passive-cron-job already configured, skipping';
+        RETURN;
+    END IF;
 
--- Reschedule with correct invoke_edge_function usage
-SELECT cron.schedule(
-    'passive-cron-job',
-    '0 2 * * *', -- At 02:00 AM
-    $$
-    SELECT invoke_edge_function('passive-mining');
-    $$
-);
+    BEGIN
+        PERFORM cron.unschedule(jobid)
+        FROM cron.job
+        WHERE jobname = 'passive-cron-job';
+    EXCEPTION WHEN OTHERS THEN
+        DELETE FROM cron.job WHERE jobname = 'passive-cron-job';
+    END;
+
+    PERFORM cron.schedule(
+        'passive-cron-job',
+        '0 2 * * *', -- At 02:00 AM
+        $$
+        SELECT invoke_edge_function('passive-mining');
+        $$
+    );
+END
+$$;


### PR DESCRIPTION
## Summary
- replace name-based unschedule/reschedule for `passive-cron-job` in `20260304160000_standardize_edge_function_invocation.sql`
- make section idempotent: skip when the job already matches expected schedule and command
- use safe cleanup by job id with fallback delete, then schedule once

## Test Plan
- verify migration SQL no longer calls `cron.unschedule('passive-cron-job')`
- `npm run precommit:check` *(fails in this environment: `lint-staged: commande introuvable`)*