### PR TITLE
fix: use distinct dollar quotes in passive cron block

### DIFF
--- a/supabase/migrations/20260304160000_standardize_edge_function_invocation.sql
+++ b/supabase/migrations/20260304160000_standardize_edge_function_invocation.sql
@@ -83,7 +83,7 @@ SELECT cron.schedule(
 -- 4. Update passive mining cron job to use invoke_edge_function correctly
 -- ============================================================================
 
-DO $$
+DO $do$
 BEGIN
     IF EXISTS (
         SELECT 1
@@ -108,9 +108,9 @@ BEGIN
     PERFORM cron.schedule(
         'passive-cron-job',
         '0 2 * * *', -- At 02:00 AM
-        $$
+        $cron$
         SELECT invoke_edge_function('passive-mining');
-        $$
+        $cron$
     );
 END
-$$;
+$do$;


### PR DESCRIPTION
## Summary
- fix SQL syntax in `20260304160000_standardize_edge_function_invocation.sql`
- use distinct dollar-quote tags for nested PL/pgSQL and cron command string
- prevent parser from terminating `DO` body early before inner `SELECT`

## Test Plan
- inspect generated migration SQL to ensure `DO $do$ ... $do$` and inner `$cron$ ... $cron$`
- `npm run precommit:check` *(fails in this environment: `lint-staged: commande introuvable`)*