### PR TITLE
fix: bring short tracking links to main

### DIFF
--- a/frontend/src/server/routes/c/[token].ts
+++ b/frontend/src/server/routes/c/[token].ts
@@ -1,0 +1,15 @@
+import { buildEmailCampaignEdgeUrl } from '../../utils/email-campaign-proxy';
+
+export default defineEventHandler((event) => {
+  const token = getRouterParam(event, 'token');
+  if (!token) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing token' });
+  }
+
+  const targetUrl = buildEmailCampaignEdgeUrl(
+    event,
+    `/track/click/${encodeURIComponent(token)}`,
+  );
+
+  return proxyRequest(event, targetUrl);
+});

--- a/frontend/src/server/routes/o/[token].ts
+++ b/frontend/src/server/routes/o/[token].ts
@@ -1,0 +1,15 @@
+import { buildEmailCampaignEdgeUrl } from '../../utils/email-campaign-proxy';
+
+export default defineEventHandler((event) => {
+  const token = getRouterParam(event, 'token');
+  if (!token) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing token' });
+  }
+
+  const targetUrl = buildEmailCampaignEdgeUrl(
+    event,
+    `/track/open/${encodeURIComponent(token)}`,
+  );
+
+  return proxyRequest(event, targetUrl);
+});

--- a/frontend/src/server/routes/u/[token].ts
+++ b/frontend/src/server/routes/u/[token].ts
@@ -1,0 +1,15 @@
+import { buildEmailCampaignEdgeUrl } from '../../utils/email-campaign-proxy';
+
+export default defineEventHandler((event) => {
+  const token = getRouterParam(event, 'token');
+  if (!token) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing token' });
+  }
+
+  const targetUrl = buildEmailCampaignEdgeUrl(
+    event,
+    `/unsubscribe/${encodeURIComponent(token)}`,
+  );
+
+  return proxyRequest(event, targetUrl);
+});

--- a/frontend/src/server/utils/email-campaign-proxy.ts
+++ b/frontend/src/server/utils/email-campaign-proxy.ts
@@ -1,0 +1,21 @@
+import type { H3Event } from "h3";
+
+export function buildEmailCampaignEdgeUrl(
+  event: H3Event,
+  path: string,
+): string {
+  const config = useRuntimeConfig(event);
+  const baseUrl =
+    config.public?.SAAS_SUPABASE_PROJECT_URL || process.env.SAAS_SUPABASE_PROJECT_URL;
+
+  if (!baseUrl) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Missing SAAS_SUPABASE_PROJECT_URL",
+    });
+  }
+
+  const normalizedBase = String(baseUrl).replace(/\/$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBase}/functions/v1/email-campaigns${normalizedPath}`;
+}

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,11 @@
+import corsHeaders from "./cors.ts";
+
+export const buildRedirectResponse = (location: string): Response => {
+  const headers = new Headers(corsHeaders);
+  headers.set("Location", location);
+
+  return new Response(null, {
+    status: 302,
+    headers,
+  });
+};

--- a/supabase/functions/email-campaigns/http.test.ts
+++ b/supabase/functions/email-campaigns/http.test.ts
@@ -1,0 +1,15 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import corsHeaders from "../_shared/cors.ts";
+import { buildRedirectResponse } from "../_shared/http.ts";
+
+Deno.test("buildRedirectResponse returns redirect with cors headers", () => {
+  const location = "https://example.com/redirect";
+  const response = buildRedirectResponse(location);
+
+  assertEquals(response.status, 302);
+  assertEquals(response.headers.get("Location"), location);
+
+  Object.entries(corsHeaders).forEach(([key, value]) => {
+    assertEquals(response.headers.get(key), value);
+  });
+});

--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -10,6 +10,7 @@ import { normalizeEmail } from "../_shared/email.ts";
 import { resolveCampaignBaseUrlFromEnv } from "../_shared/url.ts";
 import { fillTemplate } from "../_shared/mailing/template.ts";
 import { sendEmail, verifyTransport } from "./email.ts";
+import { buildRedirectResponse } from "../_shared/http.ts";
 import {
   getSenderCredentialIssue,
   isTokenExpired,
@@ -375,7 +376,18 @@ function toHtmlFromText(template: string): string {
 }
 
 function buildUnsubscribeUrl(token: string): string {
-  return `${PUBLIC_CAMPAIGN_BASE_URL}/functions/v1/email-campaigns/unsubscribe/${token}`;
+  const base = (FRONTEND_HOST || PUBLIC_CAMPAIGN_BASE_URL).replace(/\/$/, "");
+  return `${base}/u/${token}`;
+}
+
+function buildOpenTrackingUrl(token: string): string {
+  const base = (FRONTEND_HOST || PUBLIC_CAMPAIGN_BASE_URL).replace(/\/$/, "");
+  return `${base}/o/${token}`;
+}
+
+function buildClickTrackingUrl(token: string): string {
+  const base = (FRONTEND_HOST || PUBLIC_CAMPAIGN_BASE_URL).replace(/\/$/, "");
+  return `${base}/c/${token}`;
 }
 
 async function triggerCampaignProcessorFromEdge() {
@@ -1041,7 +1053,7 @@ async function injectTrackers(
         recipientId,
         originalUrl,
       );
-      const trackedUrl = `${PUBLIC_CAMPAIGN_BASE_URL}/functions/v1/email-campaigns/track/click/${token}`;
+      const trackedUrl = buildClickTrackingUrl(token);
 
       // Replace both quoted-printable encoded (href=3D"...") and regular (href="...")
       updatedHtml = updatedHtml.replace(
@@ -1055,7 +1067,7 @@ async function injectTrackers(
   }
 
   if (trackOpen) {
-    const pixelUrl = `${PUBLIC_CAMPAIGN_BASE_URL}/functions/v1/email-campaigns/track/open/${openToken}`;
+    const pixelUrl = buildOpenTrackingUrl(openToken);
     updatedHtml += `<img src="${pixelUrl}" alt="" width="1" height="1" style="display:none" />`;
   }
 
@@ -2039,13 +2051,9 @@ app.get("/unsubscribe/:token", async (c: Context) => {
   const supabaseAdmin = createSupabaseAdmin();
 
   if (token === "preview-unsubscribe") {
-    return new Response(null, {
-      status: 302,
-      headers: {
-        ...corsHeaders,
-        Location: `${FRONTEND_HOST}/unsubscribe/success?preview=true`,
-      },
-    });
+    return buildRedirectResponse(
+      `${FRONTEND_HOST}/unsubscribe/success?preview=true`,
+    );
   }
 
   const { data: recipient, error } = await supabaseAdmin
@@ -2056,13 +2064,7 @@ app.get("/unsubscribe/:token", async (c: Context) => {
     .single();
 
   if (error || !recipient) {
-    return new Response(null, {
-      status: 302,
-      headers: {
-        ...corsHeaders,
-        Location: `${FRONTEND_HOST}/unsubscribe/failure`,
-      },
-    });
+    return buildRedirectResponse(`${FRONTEND_HOST}/unsubscribe/failure`);
   }
 
   await supabaseAdmin
@@ -2110,13 +2112,7 @@ app.get("/unsubscribe/:token", async (c: Context) => {
       )}`
     : `${FRONTEND_HOST}/unsubscribe/success`;
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      ...corsHeaders,
-      Location: successUrl,
-    },
-  });
+  return buildRedirectResponse(successUrl);
 });
 
 app.get("/track/open/:token", async (c: Context) => {
@@ -2174,7 +2170,7 @@ app.get("/track/click/:token", async (c: Context) => {
     url: link.url,
   });
 
-  return c.redirect(link.url, 302);
+  return buildRedirectResponse(link.url);
 });
 
 app.post("/email-sending-request", authMiddleware, async (c: Context) => {


### PR DESCRIPTION
## Summary
- cherry-pick short-link tracking changes previously merged only into `fix/ui-sender-default-500-toast-layout`
- add Nuxt redirect routes (`/c/:token`, `/o/:token`, `/u/:token`) and proxy utility for email campaign tracking endpoints
- update email-campaigns edge function link generation to emit short frontend links

## Test Plan
- run `deno test supabase/functions/email-campaigns/http.test.ts`