### PR TITLE
fix: short token campaign queuedCount ReferenceError

### DIFF
--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -1544,7 +1544,7 @@ app.post("/campaigns/create", authMiddleware, async (c: Context) => {
   return c.json({
     msg: "Campaign queued",
     campaignId,
-    queuedCount: recipientRows.length,
+    queuedCount: eligibleContacts.length,
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: recipientRows is not defined` when creating a campaign
- Use `eligibleContacts.length` instead of `recipientRows.length` since `recipientRows` is block-scoped inside the retry loop

## Test Plan
- Verify campaign creation works without errors