### PR TITLE
fix: allow PST and file mining to start without activeMiningSource

### DIFF
--- a/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
+++ b/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
@@ -109,6 +109,7 @@ import { FetchError } from 'ofetch';
 import type { TreeSelectionKeys } from 'primevue/tree';
 
 import ProgressCard from '@/components/mining/ProgressCard.vue';
+import { requiresActiveMiningSource } from '@/utils/mining-source-guards';
 import { useWebNotification } from '@vueuse/core';
 import type { MiningSource } from '~/types/mining';
 import MiningSettingsDialog from './MiningSettingsDialog.vue';
@@ -136,8 +137,8 @@ const $supabase = useSupabaseClient();
 
 async function handleAuthErrorAndRetry(
   retryFn: () => Promise<void>,
-  sourceEmail: string,
-  sourceTypeVal: string,
+  sourceEmail?: string,
+  sourceTypeVal?: string,
 ) {
   try {
     const { error: refreshError } = await $supabase.auth.refreshSession();
@@ -146,7 +147,12 @@ async function handleAuthErrorAndRetry(
     }
     await retryFn();
   } catch (error) {
-    if (error instanceof FetchError && error.response?.status === 401) {
+    if (
+      error instanceof FetchError &&
+      error.response?.status === 401 &&
+      sourceEmail &&
+      sourceTypeVal
+    ) {
       $consentSidebar.show(
         sourceTypeVal as 'google' | 'microsoft' | 'imap',
         sourceEmail,
@@ -349,33 +355,33 @@ async function startMiningBoxes() {
     return;
   }
   canceled.value = false;
-  if (!$leadminerStore.activeMiningSource) return;
+
+  if (
+    requiresActiveMiningSource(sourceType.value) &&
+    !$leadminerStore.activeMiningSource
+  ) {
+    return;
+  }
+
+  const activeSource = $leadminerStore.activeMiningSource;
+  if (!activeSource) return;
+
   await handleAuthErrorAndRetry(
     () => $leadminerStore.startMining(sourceType.value),
-    $leadminerStore.activeMiningSource.email,
-    $leadminerStore.activeMiningSource.type,
+    activeSource.email,
+    activeSource.type,
   );
 }
 
 async function startMiningFile() {
-  if (!$leadminerStore.activeMiningSource) return;
-  await handleAuthErrorAndRetry(
-    () => $leadminerStore.startMining(sourceType.value),
-    $leadminerStore.activeMiningSource.email,
-    $leadminerStore.activeMiningSource.type,
+  await handleAuthErrorAndRetry(() =>
+    $leadminerStore.startMining(sourceType.value),
   );
 }
 
 async function startMiningPst() {
-  if (!$leadminerStore.activeMiningSource) return;
-  await handleAuthErrorAndRetry(
-    () =>
-      $leadminerStore.startMining(
-        sourceType.value,
-        $leadminerStore.pstFilePath,
-      ),
-    $leadminerStore.activeMiningSource.email,
-    $leadminerStore.activeMiningSource.type,
+  await handleAuthErrorAndRetry(() =>
+    $leadminerStore.startMining(sourceType.value, $leadminerStore.pstFilePath),
   );
 }
 

--- a/frontend/src/tests/unit/mining-source-guards.test.ts
+++ b/frontend/src/tests/unit/mining-source-guards.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { requiresActiveMiningSource } from '@/utils/mining-source-guards';
+
+describe('requiresActiveMiningSource', () => {
+  it('requires an active source only for email mining', () => {
+    expect(requiresActiveMiningSource('email')).toBe(true);
+    expect(requiresActiveMiningSource('file')).toBe(false);
+    expect(requiresActiveMiningSource('pst')).toBe(false);
+  });
+});

--- a/frontend/src/utils/mining-source-guards.ts
+++ b/frontend/src/utils/mining-source-guards.ts
@@ -1,0 +1,5 @@
+import type { MiningType } from '~/types/mining';
+
+export function requiresActiveMiningSource(miningType: MiningType): boolean {
+  return miningType === 'email';
+}


### PR DESCRIPTION
## Summary

- Fixes PST mining start button not triggering any API call when clicked
- Removes incorrect `activeMiningSource` guard for `file` and `pst` mining types
- Adds guard utility to only require active source for email mining
- Adds unit test for mining source guard logic

## Root Cause

`startMiningPst()` and `startMiningFile()` were checking for `activeMiningSource` which is only set for email mining sources (Google, Microsoft, IMAP). PST and file mining don't use this field, causing the functions to return early without making any API call.