### PR TITLE
fix: add reconnect button to unavailable senders toast and sources page

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -953,9 +953,28 @@ async function loadSenderOptions() {
       $toast.add({
         severity: 'warn',
         summary: t('senders_unavailable_title'),
-        detail: t('senders_unavailable_notification', {
-          emails: unavailableEmails.join(', '),
-        }),
+        detail: {
+          message: t('senders_unavailable_notification', {
+            emails: unavailableEmails.join(', '),
+          }),
+          button: {
+            text:
+              unavailableEmails.length === 1
+                ? t('reconnect_source')
+                : t('go_to_sources'),
+            action: () => {
+              if (unavailableEmails.length === 1) {
+                navigateTo(
+                  `/sources?reconnect=${encodeURIComponent(
+                    unavailableEmails[0],
+                  )}`,
+                );
+              } else {
+                navigateTo('/sources');
+              }
+            },
+          },
+        },
         life: 6500,
       });
     }
@@ -1265,6 +1284,8 @@ watch(
     "sender_email_help": "The email address used to send this campaign.",
     "senders_unavailable_title": "Some sender addresses are unavailable",
     "senders_unavailable_notification": "The following addresses are no longer available: {emails}. Please reconnect them in Sources.",
+    "reconnect_source": "Reconnect",
+    "go_to_sources": "Go to Sources",
     "reply_to": "Reply-to",
     "reply_to_help": "Replies from recipients will be sent to this email address.",
     "subject": "Subject",
@@ -1359,6 +1380,8 @@ watch(
     "sender_email_help": "Adresse email utilisée pour envoyer cette campagne.",
     "senders_unavailable_title": "Certaines adresses d'expédition sont indisponibles",
     "senders_unavailable_notification": "Les adresses suivantes ne sont plus disponibles : {emails}. Veuillez les reconnecter dans les sources.",
+    "reconnect_source": "Reconnecter",
+    "go_to_sources": "Aller aux sources",
     "reply_to": "Répondre à",
     "reply_to_help": "Les réponses de vos destinataires seront envoyées à cette adresse.",
     "subject": "Sujet",

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -84,18 +84,19 @@
                   @click="openDeleteDialog(source)"
                 />
 
-                <button
-                  v-if="!source.isValid"
-                  type="button"
-                  class="rounded-sm"
-                  @click="reconnectExpiredSource(source)"
-                >
+                <div v-if="!source.isValid" class="flex gap-2 items-center">
                   <Tag
                     :value="t(getSourceStatusBadge(source).labelKey)"
                     :severity="getSourceStatusBadge(source).severity"
                     :icon="getSourceStatusBadge(source).icon"
                   />
-                </button>
+                  <Button
+                    :label="t('reconnect')"
+                    size="small"
+                    severity="warn"
+                    @click="reconnectExpiredSource(source)"
+                  />
+                </div>
                 <Tag
                   v-else
                   :value="t(getSourceStatusBadge(source).labelKey)"
@@ -224,10 +225,36 @@ const { t } = useI18n({
 });
 const { $api, $saasEdgeFunctions } = useNuxtApp();
 const $toast = useToast();
+const $route = useRoute();
+const $router = useRouter();
+const $imapDialogStore = useImapDialog();
 
 const deleteDialogVisible = ref(false);
 const deletingSource = ref<MiningSource | null>(null);
 const isDeleting = ref(false);
+
+onMounted(async () => {
+  const reconnectEmail = $route.query.reconnect as string;
+
+  if (reconnectEmail) {
+    const source = $leadminer.miningSources.find(
+      (s) => s.email.toLowerCase() === reconnectEmail.toLowerCase(),
+    );
+
+    if (source && !source.isValid) {
+      $router.replace({ query: {} });
+
+      if (source.type === 'imap') {
+        $imapDialogStore.imapEmail = source.email;
+        $imapDialogStore.showImapDialog = true;
+      } else {
+        await reconnectExpiredSource(source);
+      }
+    } else {
+      $router.replace({ query: {} });
+    }
+  }
+});
 
 function getIcon(type: string) {
   switch (type) {
@@ -432,6 +459,7 @@ onMounted(async () => {
     "reconnect_unavailable": "Reconnect URL is unavailable",
     "reconnect_not_supported": "Reconnect not supported",
     "reconnect_not_supported_detail": "This source requires manual credential update.",
+    "reconnect": "Reconnect",
     "emails_scanned": "Scanned",
     "emails_extracted": "Extracted",
     "emails_cleaned": "Cleaned",
@@ -481,6 +509,7 @@ onMounted(async () => {
     "reconnect_unavailable": "URL de reconnexion indisponible",
     "reconnect_not_supported": "Reconnexion non prise en charge",
     "reconnect_not_supported_detail": "Cette source nécessite une mise à jour manuelle des identifiants.",
+    "reconnect": "Reconnecter",
     "emails_scanned": "Scannés",
     "emails_extracted": "Extracts",
     "emails_cleaned": "Nettoyés",


### PR DESCRIPTION
## Summary
- Add action button to the "unavailable senders" toast in CampaignComposerDialog that redirects to `/sources?reconnect={email}`
- Add route handling in Sources page to process `?reconnect={email}` query param:
  - For IMAP sources: opens the IMAP connection dialog with pre-filled email
  - For Google/Azure sources: triggers the OAuth reconnection flow
- Replace the unclear clickable Tag with an explicit "Reconnect" button + status badge

## Changes
- `frontend/src/components/campaigns/CampaignComposerDialog.vue`: Toast now has a button with action
- `frontend/src/pages/sources.vue`: Added onMounted handler for reconnect query param, explicit Reconnect button UI