### PR TITLE
fix: add group has-links to toast and use primary severity for reconnect button

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -975,6 +975,7 @@ async function loadSenderOptions() {
             },
           },
         },
+        group: 'has-links',
         life: 6500,
       });
     }

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -93,7 +93,7 @@
                   <Button
                     :label="t('reconnect')"
                     size="small"
-                    severity="warn"
+                    severity="primary"
                     @click="reconnectExpiredSource(source)"
                   />
                 </div>


### PR DESCRIPTION
## Summary
- Add `group: 'has-links'` to the unavailable senders toast so it renders properly with message and button
- Change Reconnect button severity from "warn" to "primary" (blue) to match design system

## Changes
- `frontend/src/components/campaigns/CampaignComposerDialog.vue`: Add `group: 'has-links'`
- `frontend/src/pages/sources.vue`: Change severity from `warn` to `primary`