### PR TITLE
fix: fix tab spacing and add FALLBACK_SENDER_ENABLED env var

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -25,7 +25,7 @@
       <Button
         icon="pi pi-envelope"
         outlined
-        class="ml-4 border-b-2 border-0 rounded-sm invisible lg:visible hover:border-primary"
+        class="ml-2 border-b-2 border-0 rounded-sm invisible lg:visible hover:border-primary"
         :class="{
           'border-primary': $router.currentRoute.value.path === sourcesPath,
         }"

--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -43,6 +43,7 @@ const PUBLIC_CAMPAIGN_BASE_URL = resolveCampaignBaseUrlFromEnv((key) =>
   Deno.env.get(key),
 );
 const SMTP_USER = normalizeEmail(Deno.env.get("SMTP_USER") || "");
+const FALLBACK_SENDER_ENABLED = Boolean(Deno.env.get("FALLBACK_SENDER_ENABLED") !== "false");
 const FRONTEND_HOST = Deno.env.get("FRONTEND_HOST") || "";
 const DEFAULT_SENDER_DAILY_LIMIT = 1000;
 const MAX_SENDER_DAILY_LIMIT = 2000;
@@ -212,7 +213,14 @@ function requireFallbackSenderEmail() {
   if (!SMTP_USER) {
     throw new Error("SMTP_USER is not configured");
   }
+  if (!FALLBACK_SENDER_ENABLED) {
+    throw new Error("Fallback sender is disabled via FALLBACK_SENDER_ENABLED env var");
+  }
   return SMTP_USER;
+}
+
+function isFallbackSenderEnabled(): boolean {
+  return Boolean(SMTP_USER && FALLBACK_SENDER_ENABLED);
 }
 
 function parseErrorCode(error: unknown): string {
@@ -686,11 +694,11 @@ async function buildUserTransport(
 }
 
 async function resolveSenderOptions(authorization: string, userEmail: string) {
-  const fallbackSenderEmail = requireFallbackSenderEmail();
+  const fallbackSenderEmail = isFallbackSenderEnabled() ? requireFallbackSenderEmail() : "";
   const options: SenderOption[] = [];
-  const transportBySender: Record<string, Transport | null> = {
-    [fallbackSenderEmail]: null,
-  };
+  const transportBySender: Record<string, Transport | null> = fallbackSenderEmail
+    ? { [fallbackSenderEmail]: null }
+    : {};
 
   const sources = listUniqueSenderSources(
     await getUserMiningSources(authorization),
@@ -802,14 +810,16 @@ async function resolveSenderOptions(authorization: string, userEmail: string) {
     });
   }
 
-  const fallbackOption = options.find(
-    (option) => option.email === fallbackSenderEmail,
-  );
-  if (fallbackOption) {
-    fallbackOption.available = true;
-    delete fallbackOption.reason;
-  } else {
-    options.push({ email: fallbackSenderEmail, available: true });
+  if (fallbackSenderEmail) {
+    const fallbackOption = options.find(
+      (option) => option.email === fallbackSenderEmail,
+    );
+    if (fallbackOption) {
+      fallbackOption.available = true;
+      delete fallbackOption.reason;
+    } else {
+      options.push({ email: fallbackSenderEmail, available: true });
+    }
   }
 
   return {
@@ -1691,6 +1701,15 @@ app.post(
   async (c: Context) => {
     const supabaseAdmin = createSupabaseAdmin();
     let fallbackSenderEmail = "";
+    if (!isFallbackSenderEnabled()) {
+      return c.json(
+        {
+          error: "Fallback sender is disabled",
+          code: "FALLBACK_SENDER_DISABLED",
+        },
+        500,
+      );
+    }
     try {
       fallbackSenderEmail = requireFallbackSenderEmail();
     } catch (error) {
@@ -2263,6 +2282,15 @@ app.post("/email-sending-request", authMiddleware, async (c: Context) => {
 
   const subject = "Email sending request";
   let fallbackSenderEmail = "";
+  if (!isFallbackSenderEnabled()) {
+    return c.json(
+      {
+        error: "Fallback sender is disabled",
+        code: "FALLBACK_SENDER_DISABLED",
+      },
+      500,
+    );
+  }
   try {
     fallbackSenderEmail = requireFallbackSenderEmail();
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fix inconsistent tab spacing between Campaigns and Sources (changed ml-4 to ml-2)
- Add FALLBACK_SENDER_ENABLED env var to optionally disable fallback sender (default: true)
- When FALLBACK_SENDER_ENABLED=false, the fallback sender is not added to sender options

## Changes
- `frontend/src/components/AppHeader.vue`: Fixed ml-4 to ml-2 for Sources button
- `supabase/functions/email-campaigns/index.ts`: Added FALLBACK_SENDER_ENABLED env var check

## Environment Variable
- `FALLBACK_SENDER_ENABLED` (default: true) - Set to "false" to disable fallback sender