### PR TITLE
fix: show message when no sender options and add source button in sources page

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -64,7 +64,18 @@
               class="pi pi-info-circle text-xs text-surface-500"
             />
           </label>
+          <template v-if="hasNoSenderOptions">
+            <Message severity="warn" :closable="false" class="text-sm">
+              {{ t('no_sender_options') }}
+            </Message>
+            <Button
+              outlined
+              :label="t('go_to_sources')"
+              @click="navigateTo('/sources')"
+            />
+          </template>
           <Select
+            v-else
             v-model="form.senderEmail"
             :options="senderOptions"
             option-label="label"
@@ -416,6 +427,7 @@ type SenderOptionItem = {
 };
 
 const senderOptions = ref<SenderOptionItem[]>([]);
+const hasNoSenderOptions = computed(() => senderOptions.value.length === 0 && !isLoadingSenderOptions.value);
 const fallbackSenderEmail = ref('');
 const runtimeConfig = useRuntimeConfig();
 const complianceDialogRef = ref<InstanceType<typeof ComplianceDialog> | null>(
@@ -1287,6 +1299,7 @@ watch(
     "senders_unavailable_notification": "The following addresses are no longer available: {emails}. Please reconnect them in Sources.",
     "reconnect_source": "Reconnect",
     "go_to_sources": "Go to Sources",
+    "no_sender_options": "No email source available. Add or reconnect a source to send campaigns.",
     "reply_to": "Reply-to",
     "reply_to_help": "Replies from recipients will be sent to this email address.",
     "subject": "Subject",
@@ -1383,6 +1396,7 @@ watch(
     "senders_unavailable_notification": "Les adresses suivantes ne sont plus disponibles : {emails}. Veuillez les reconnecter dans les sources.",
     "reconnect_source": "Reconnecter",
     "go_to_sources": "Aller aux sources",
+    "no_sender_options": "Aucune source d'email disponible. Ajoutez ou reconnectez une source pour envoyer des campagnes.",
     "reply_to": "Répondre à",
     "reply_to_help": "Les réponses de vos destinataires seront envoyées à cette adresse.",
     "subject": "Sujet",

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -4,7 +4,49 @@
   >
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold">{{ t('sources') }}</h1>
+      <Button
+        icon="pi pi-plus"
+        :label="t('add_source')"
+        @click="showAddSourceDialog = true"
+      />
     </div>
+
+    <Dialog
+      v-model:visible="showAddSourceDialog"
+      modal
+      :header="t('add_source')"
+      :style="{ width: '30rem' }"
+    >
+      <div class="flex flex-col gap-3">
+        <Button
+          class="w-full justify-start"
+          severity="secondary"
+          outlined
+          @click="addGoogleSource"
+        >
+          <i class="pi pi-google mr-2" />
+          Google
+        </Button>
+        <Button
+          class="w-full justify-start"
+          severity="secondary"
+          outlined
+          @click="addAzureSource"
+        >
+          <i class="pi pi-microsoft mr-2" />
+          Outlook / Office 365
+        </Button>
+        <Button
+          class="w-full justify-start"
+          severity="secondary"
+          outlined
+          @click="addImapSource"
+        >
+          <i class="pi pi-inbox mr-2" />
+          IMAP
+        </Button>
+      </div>
+    </Dialog>
 
     <div
       v-if="
@@ -232,6 +274,59 @@ const $imapDialogStore = useImapDialog();
 const deleteDialogVisible = ref(false);
 const deletingSource = ref<MiningSource | null>(null);
 const isDeleting = ref(false);
+const showAddSourceDialog = ref(false);
+
+async function addGoogleSource() {
+  showAddSourceDialog.value = false;
+  try {
+    const { authorizationUri } = await $api<{ authorizationUri: string }>(
+      '/imap/mine/sources/google',
+      {
+        method: 'POST',
+        body: { redirect: '/sources' },
+      },
+    );
+    if (authorizationUri) {
+      window.location.href = authorizationUri;
+    }
+  } catch (error) {
+    $toast.add({
+      severity: 'error',
+      summary: t('add_source_failed'),
+      detail: t('add_source_failed_detail'),
+      life: 4500,
+    });
+  }
+}
+
+async function addAzureSource() {
+  showAddSourceDialog.value = false;
+  try {
+    const { authorizationUri } = await $api<{ authorizationUri: string }>(
+      '/imap/mine/sources/azure',
+      {
+        method: 'POST',
+        body: { redirect: '/sources' },
+      },
+    );
+    if (authorizationUri) {
+      window.location.href = authorizationUri;
+    }
+  } catch (error) {
+    $toast.add({
+      severity: 'error',
+      summary: t('add_source_failed'),
+      detail: t('add_source_failed_detail'),
+      life: 4500,
+    });
+  }
+}
+
+function addImapSource() {
+  showAddSourceDialog.value = false;
+  $imapDialogStore.imapEmail = '';
+  $imapDialogStore.showImapDialog = true;
+}
 
 onMounted(async () => {
   const reconnectEmail = $route.query.reconnect as string;
@@ -422,6 +517,9 @@ onMounted(async () => {
 {
   "en": {
     "sources": "Sources",
+    "add_source": "Add source",
+    "add_source_failed": "Unable to add source",
+    "add_source_failed_detail": "An error occurred while adding the source.",
     "no_sources": "No sources yet",
     "email": "Email",
     "provider": "Provider",
@@ -472,6 +570,9 @@ onMounted(async () => {
   },
   "fr": {
     "sources": "Sources",
+    "add_source": "Ajouter une source",
+    "add_source_failed": "Impossible d'ajouter la source",
+    "add_source_failed_detail": "Une erreur s'est produite lors de l'ajout de la source.",
     "no_sources": "Aucune source",
     "email": "Email",
     "provider": "Fournisseur",


### PR DESCRIPTION
## Summary
- When no sender email options available in campaign composer, show a warning message with a button to navigate to Sources
- Add "Add source" button in Sources page header that opens a dialog with options: Google, Azure (Outlook), and IMAP

## Changes
- `CampaignComposerDialog.vue`: Show warning message + "Go to Sources" button when sender options are empty
- `sources.vue`: Add "Add source" button with dialog (Google OAuth, Azure OAuth, IMAP - no PST)