### PR TITLE
fix: match add-source header button text color with campaigns refresh

### DIFF
--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -8,7 +8,6 @@
         v-if="$leadminer.miningSources.length > 0"
         icon="pi pi-plus"
         outlined
-        severity="secondary"
         :label="t('add_source')"
         @click="showAddSourceDialog = true"
       />


### PR DESCRIPTION
## Summary
- Remove `severity=\"secondary\"` from Sources header Add source button
- Keep button outlined so it matches the text color/visual style used by the Refresh button in Campaigns

## File
- `frontend/src/pages/sources.vue`