### PR TITLE
fix: load mining sources before reconnect query handling

### DIFF
--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -320,29 +320,6 @@ function openImapFromAddSource() {
   });
 }
 
-onMounted(async () => {
-  const reconnectEmail = $route.query.reconnect as string;
-
-  if (reconnectEmail) {
-    const source = $leadminer.miningSources.find(
-      (s) => s.email.toLowerCase() === reconnectEmail.toLowerCase(),
-    );
-
-    if (source && !source.isValid) {
-      $router.replace({ query: {} });
-
-      if (source.type === 'imap') {
-        $imapDialogStore.imapEmail = source.email;
-        $imapDialogStore.showImapDialog = true;
-      } else {
-        await reconnectExpiredSource(source);
-      }
-    } else {
-      $router.replace({ query: {} });
-    }
-  }
-});
-
 function getIcon(type: string) {
   switch (type) {
     case 'google':
@@ -504,8 +481,29 @@ async function reconnectExpiredSource(source: MiningSource) {
 }
 
 onMounted(async () => {
+  const reconnectEmail = $route.query.reconnect as string;
+
   await $leadminer.fetchMiningSources();
   await $leadminer.getCurrentRunningMining();
+
+  if (reconnectEmail) {
+    const source = $leadminer.miningSources.find(
+      (s) => s.email.toLowerCase() === reconnectEmail.toLowerCase(),
+    );
+
+    if (source && !source.isValid) {
+      $router.replace({ query: {} });
+
+      if (source.type === 'imap') {
+        $imapDialogStore.imapEmail = source.email;
+        $imapDialogStore.showImapDialog = true;
+      } else {
+        await reconnectExpiredSource(source);
+      }
+    } else {
+      $router.replace({ query: {} });
+    }
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- Fix `/sources?reconnect=<email>` reconnect flow by loading mining sources before resolving the reconnect email.
- Consolidate duplicate `onMounted` logic in `sources.vue` into a single mount path that first fetches data, then applies reconnect behavior.
- Preserve existing reconnect behavior for OAuth and IMAP sources while preventing the empty-sources race condition.

## Test Plan
- [x] `npx eslint src/pages/sources.vue`
- [x] `npm run test -- sender-options.test.ts --run`