### PR TITLE
fix: handle reconnect links for deleted sources

### DIFF
--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -265,6 +265,7 @@
 <script setup lang="ts">
 import AddSourceImap from '@/components/mining/stepper-panels/source/AddSourceImap.vue';
 import { addOAuthAccount } from '@/utils/oauth';
+import { resolveReconnectFallbackAction } from '@/utils/reconnectFallback';
 import type { MiningSource } from '~/types/mining';
 import { resolveSourceStatusBadge } from '@/utils/sourceStatusBadge';
 
@@ -491,8 +492,10 @@ onMounted(async () => {
       (s) => s.email.toLowerCase() === reconnectEmail.toLowerCase(),
     );
 
+    const clearReconnectQuery = () => $router.replace({ query: {} });
+
     if (source && !source.isValid) {
-      $router.replace({ query: {} });
+      clearReconnectQuery();
 
       if (source.type === 'imap') {
         $imapDialogStore.imapEmail = source.email;
@@ -500,8 +503,29 @@ onMounted(async () => {
       } else {
         await reconnectExpiredSource(source);
       }
+    } else if (!source) {
+      clearReconnectQuery();
+
+      const action = resolveReconnectFallbackAction(reconnectEmail);
+
+      try {
+        if (action === 'google' || action === 'azure') {
+          await addOAuthAccount(action, '/sources');
+          return;
+        }
+      } catch {
+        $toast.add({
+          severity: 'error',
+          summary: t('add_source_failed'),
+          detail: t('add_source_failed_detail'),
+          life: 4500,
+        });
+      }
+
+      $imapDialogStore.imapEmail = reconnectEmail;
+      $imapDialogStore.showImapDialog = true;
     } else {
-      $router.replace({ query: {} });
+      clearReconnectQuery();
     }
   }
 });

--- a/frontend/src/tests/unit/reconnect-fallback.test.ts
+++ b/frontend/src/tests/unit/reconnect-fallback.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReconnectFallbackAction } from '@/utils/reconnectFallback';
+
+describe('resolveReconnectFallbackAction', () => {
+  it('returns google for gmail domains', () => {
+    expect(resolveReconnectFallbackAction('user@gmail.com')).toBe('google');
+    expect(resolveReconnectFallbackAction('user@googlemail.com')).toBe(
+      'google',
+    );
+  });
+
+  it('returns azure for microsoft-hosted domains', () => {
+    expect(resolveReconnectFallbackAction('user@outlook.com')).toBe('azure');
+    expect(resolveReconnectFallbackAction('user@hotmail.com')).toBe('azure');
+    expect(resolveReconnectFallbackAction('user@live.com')).toBe('azure');
+  });
+
+  it('returns imap for other domains', () => {
+    expect(resolveReconnectFallbackAction('user@example.com')).toBe('imap');
+  });
+});

--- a/frontend/src/utils/reconnectFallback.ts
+++ b/frontend/src/utils/reconnectFallback.ts
@@ -1,0 +1,32 @@
+type ReconnectFallbackAction = 'google' | 'azure' | 'imap';
+
+const GOOGLE_DOMAINS = new Set(['gmail.com', 'googlemail.com']);
+const AZURE_DOMAINS = new Set([
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+]);
+
+export function resolveReconnectFallbackAction(
+  email: string,
+): ReconnectFallbackAction {
+  const normalizedEmail = email.trim().toLowerCase();
+  const atIndex = normalizedEmail.lastIndexOf('@');
+
+  if (atIndex === -1 || atIndex === normalizedEmail.length - 1) {
+    return 'imap';
+  }
+
+  const domain = normalizedEmail.slice(atIndex + 1);
+
+  if (GOOGLE_DOMAINS.has(domain)) {
+    return 'google';
+  }
+
+  if (AZURE_DOMAINS.has(domain)) {
+    return 'azure';
+  }
+
+  return 'imap';
+}


### PR DESCRIPTION
## Summary
- Add fallback reconnect behavior when `/sources?reconnect=<email>` targets a source that no longer exists.
- Infer provider from email domain and auto-start OAuth onboarding for Gmail/Googlemail (`google`) and Microsoft-hosted emails (`azure`).
- Fall back to opening the IMAP dialog prefilled with the reconnect email for all other domains.

## Test Plan
- [x] `npm run test -- reconnect-fallback.test.ts --run`
- [x] `npm run test -- sender-options.test.ts --run`
- [x] `npx eslint src/pages/sources.vue src/utils/reconnectFallback.ts src/tests/unit/reconnect-fallback.test.ts`