### PR TITLE
fix keep compact contact counter for mobile only

### DIFF
--- a/frontend/src/components/mining/table/MiningTable.vue
+++ b/frontend/src/components/mining/table/MiningTable.vue
@@ -1215,7 +1215,7 @@ const isFullscreen = ref(false);
 const $screenStore = useScreenStore();
 
 function formatContactsCountForHeader(count: number) {
-  if (count < 1000) {
+  if ($screenStore.size.md || count < 1000) {
     return count.toLocaleString();
   }
 


### PR DESCRIPTION
## Summary
- restore responsive behavior for contacts counter formatting in MiningTable
- keep compact `k` formatting on mobile only
- preserve full localized numeric formatting on desktop

## Test Plan
- manual check on `/contacts`:
  - desktop shows `1 000`
  - mobile shows `1k`