### PR TITLE
fix(frontend): fix contact table checkbox selection

### DIFF
--- a/frontend/src/components/mining/table/MiningTable.vue
+++ b/frontend/src/components/mining/table/MiningTable.vue
@@ -24,7 +24,7 @@
     striped-rows
     :select-all="selectAll"
     :value="sourceRows"
-    data-key="id"
+    data-key="email"
     paginator
     filter-display="menu"
     :global-filter-fields="globalFilterFields"


### PR DESCRIPTION
## Problem
When selecting a contact in the frontend table, all contact checkboxes were being selected instead of just the one clicked, while the header showed "1/n contacts".

## Root Cause
PrimeVue DataTable was configured with data-key="id" but contacts are cached and identified by email throughout the codebase. When the DataTable could not find unique id values for comparison, it treated all rows as the same entity, causing the checkbox selection to apply to all rows.

## Solution
Changed data-key from "id" to "email" to match the actual unique identifier used in the application. Email is the consistent unique key used in contact caching, updates, and selection tracking.

## Changes
- frontend/src/components/mining/table/MiningTable.vue: Changed data-key from id to email

## Testing
- Verified the fix allows individual row selection
- Header checkbox select all functionality still works correctly