### PR TITLE
fix oauth mining redirect after google consent

### DIFF
--- a/frontend/src/components/mining/MiningStepper.vue
+++ b/frontend/src/components/mining/MiningStepper.vue
@@ -50,6 +50,7 @@
 
 <script setup lang="ts">
 import type { MiningSourceType } from '~/types/mining';
+import { resolvePostOauthSourceSelection } from '@/utils/mining-oauth-redirect';
 import MiningConsentSidebar from './MiningConsentSidebar.vue';
 import CleanPanel from './stepper-panels/clean/CleanPanel.vue';
 import MinePanel from './stepper-panels/mine/MinePanel.vue';
@@ -70,27 +71,87 @@ const sourcePanel = ref<InstanceType<typeof SourcePanel>>();
 
 const importPstDialogRef = ref();
 
-const { error, provider, source } = $route.query;
+const provider = computed(() => {
+  const providerValue = $route.query.provider;
+  return typeof providerValue === 'string' ? providerValue : undefined;
+});
 
-const selectedSource = source
-  ? $leadminerStore.getMiningSourceByEmail(source as string)
-  : null;
+const error = computed(() => {
+  const errorValue = $route.query.error;
+  return typeof errorValue === 'string' ? errorValue : undefined;
+});
 
-if (selectedSource) {
-  $leadminerStore.boxes = [];
-  $leadminerStore.selectedBoxes = [];
-  $leadminerStore.activeMiningSource = selectedSource;
-  $stepper.go(2);
-} else {
-  $stepper.go(1);
+const source = computed(() => {
+  const sourceValue = $route.query.source;
+  return typeof sourceValue === 'string' ? sourceValue : undefined;
+});
+
+const handledSourceQuery = ref<string | null>(null);
+
+function clearOauthQueryParams() {
+  const {
+    provider: _provider,
+    error: _error,
+    source: _source,
+    ...query
+  } = $route.query;
+
+  $router.replace({ query: Object.keys(query).length ? query : undefined });
 }
 
+watch(
+  [
+    source,
+    () => $leadminerStore.miningSources,
+    () => $leadminerStore.isLoadingMiningSources,
+  ],
+  ([sourceEmail, miningSources, isLoadingMiningSources]) => {
+    if (!sourceEmail) {
+      if (!handledSourceQuery.value) {
+        $stepper.go(1);
+      }
+      return;
+    }
+
+    if (handledSourceQuery.value === sourceEmail) {
+      return;
+    }
+
+    const resolution = resolvePostOauthSourceSelection({
+      querySource: sourceEmail,
+      miningSources,
+      isLoadingMiningSources,
+    });
+
+    if (resolution.status === 'wait') {
+      return;
+    }
+
+    if (resolution.status === 'select') {
+      $leadminerStore.boxes = [];
+      $leadminerStore.selectedBoxes = [];
+      $leadminerStore.activeMiningSource = resolution.source;
+      $stepper.go(2);
+    } else {
+      $stepper.go(1);
+    }
+
+    handledSourceQuery.value = sourceEmail;
+    clearOauthQueryParams();
+  },
+  { immediate: true },
+);
+
 onNuxtReady(() => {
-  if (provider && error === 'oauth-consent') {
-    $consentSidebar.show(provider as MiningSourceType, undefined, '/mine');
-    if (provider === 'azure') importPstDialogRef.value.openModal();
+  if (provider.value && error.value === 'oauth-consent') {
+    $consentSidebar.show(
+      provider.value as MiningSourceType,
+      undefined,
+      '/mine',
+    );
+    if (provider.value === 'azure') importPstDialogRef.value.openModal();
+    clearOauthQueryParams();
   }
-  $router.replace({ query: undefined });
 });
 </script>
 

--- a/frontend/src/components/mining/stepper-panels/source/SourcePanel.vue
+++ b/frontend/src/components/mining/stepper-panels/source/SourcePanel.vue
@@ -113,7 +113,7 @@ const $leadminerStore = useLeadminerStore();
 const $imapDialogStore = useImapDialog();
 const $sourcePanelStore = useStepperSourcePanel();
 const sourceOptions = computed(() => useLeadminerStore().miningSources);
-const sourceModel = ref<MiningSource | undefined>(sourceOptions?.value[0]);
+const sourceModel = ref<MiningSource | undefined>();
 
 function extractContacts(miningSource?: MiningSource) {
   if (miningSource) {
@@ -124,6 +124,30 @@ function extractContacts(miningSource?: MiningSource) {
 }
 
 $sourcePanelStore.showOtherSourcesByDefault();
+
+watch(
+  sourceOptions,
+  (options) => {
+    if (options.length > 0) {
+      $sourcePanelStore.hideOtherSources();
+
+      const selectedSourceIsStillAvailable = options.some(
+        (option) =>
+          option.email === sourceModel.value?.email &&
+          option.type === sourceModel.value?.type,
+      );
+
+      if (!selectedSourceIsStillAvailable) {
+        sourceModel.value = options[0];
+      }
+
+      return;
+    }
+
+    sourceModel.value = undefined;
+  },
+  { immediate: true },
+);
 
 function getIcon(type: string) {
   switch (type) {

--- a/frontend/src/tests/unit/mining-oauth-redirect.test.ts
+++ b/frontend/src/tests/unit/mining-oauth-redirect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePostOauthSourceSelection } from '@/utils/mining-oauth-redirect';
+import type { MiningSource } from '@/types/mining';
+
+const googleSource: MiningSource = {
+  type: 'google',
+  email: 'user@example.com',
+  passive_mining: false,
+};
+
+describe('resolvePostOauthSourceSelection', () => {
+  it('waits while sources are still loading after oauth redirect', () => {
+    const result = resolvePostOauthSourceSelection({
+      querySource: 'user@example.com',
+      miningSources: [],
+      isLoadingMiningSources: true,
+    });
+
+    expect(result).toEqual({
+      status: 'wait',
+    });
+  });
+
+  it('selects source when it becomes available after loading', () => {
+    const result = resolvePostOauthSourceSelection({
+      querySource: 'USER@example.com',
+      miningSources: [googleSource],
+      isLoadingMiningSources: false,
+    });
+
+    expect(result).toEqual({
+      status: 'select',
+      source: googleSource,
+    });
+  });
+
+  it('falls back to source step when oauth source is missing after load', () => {
+    const result = resolvePostOauthSourceSelection({
+      querySource: 'missing@example.com',
+      miningSources: [googleSource],
+      isLoadingMiningSources: false,
+    });
+
+    expect(result).toEqual({
+      status: 'fallback',
+    });
+  });
+});

--- a/frontend/src/utils/mining-oauth-redirect.ts
+++ b/frontend/src/utils/mining-oauth-redirect.ts
@@ -1,0 +1,52 @@
+import type { MiningSource } from '@/types/mining';
+
+type PostOauthSourceSelectionInput = {
+  querySource?: string;
+  miningSources: MiningSource[];
+  isLoadingMiningSources: boolean;
+};
+
+type PostOauthSourceSelectionResult =
+  | { status: 'wait' }
+  | { status: 'fallback' }
+  | { status: 'select'; source: MiningSource };
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function findMiningSourceByEmail(
+  miningSources: MiningSource[],
+  email: string,
+) {
+  const normalizedEmail = normalizeEmail(email);
+
+  return miningSources.find(
+    (source) => normalizeEmail(source.email) === normalizedEmail,
+  );
+}
+
+export function resolvePostOauthSourceSelection({
+  querySource,
+  miningSources,
+  isLoadingMiningSources,
+}: PostOauthSourceSelectionInput): PostOauthSourceSelectionResult {
+  if (!querySource) {
+    return { status: 'fallback' };
+  }
+
+  const selectedSource = findMiningSourceByEmail(miningSources, querySource);
+
+  if (selectedSource) {
+    return {
+      status: 'select',
+      source: selectedSource,
+    };
+  }
+
+  if (isLoadingMiningSources) {
+    return { status: 'wait' };
+  }
+
+  return { status: 'fallback' };
+}


### PR DESCRIPTION
## Summary
- make post-OAuth source selection reactive in mining stepper to avoid falling back to source chooser when sources arrive slightly later
- keep the source panel in sync with dynamically loaded sources so existing sources are shown as soon as they are available
- add focused unit coverage for the post-OAuth resolution logic (`wait`, `select`, `fallback`)

## Test Plan
- npm run test -- src/tests/unit/mining-oauth-redirect.test.ts src/tests/unit/mining-source-guards.test.ts src/tests/unit/reconnect-fallback.test.ts src/tests/unit/sender-options.test.ts --run