### PR TITLE
fix: restore missing migration versions for qa sync

### DIFF
--- a/supabase/migrations/20241008210613_legacy_remote_migration_placeholder.sql
+++ b/supabase/migrations/20241008210613_legacy_remote_migration_placeholder.sql
@@ -1,0 +1,11 @@
+-- Legacy placeholder migration.
+--
+-- This version exists in remote migration history but its original SQL file
+-- is not present in this repository history. Keeping this placeholder keeps
+-- CLI migration version reconciliation stable across environments.
+
+DO $$
+BEGIN
+  -- no-op
+END
+$$;

--- a/supabase/migrations/20241206143825_legacy_remote_migration_placeholder.sql
+++ b/supabase/migrations/20241206143825_legacy_remote_migration_placeholder.sql
@@ -1,0 +1,11 @@
+-- Legacy placeholder migration.
+--
+-- This version exists in remote migration history but its original SQL file
+-- is not present in this repository history. Keeping this placeholder keeps
+-- CLI migration version reconciliation stable across environments.
+
+DO $$
+BEGIN
+  -- no-op
+END
+$$;

--- a/supabase/migrations/20251120150626_fix_get_distinct_or_exclude_from_array.sql
+++ b/supabase/migrations/20251120150626_fix_get_distinct_or_exclude_from_array.sql
@@ -1,0 +1,39 @@
+DROP FUNCTION private.get_distinct_or_exclude_from_array;
+
+CREATE FUNCTION private.get_distinct_or_exclude_from_array(
+    input_array text[],
+    exclude_array text[] DEFAULT NULL
+)
+RETURNS text[]
+LANGUAGE sql
+AS $$
+    WITH normalized AS (
+        SELECT
+            val AS original,
+            lower(trim(val)) AS norm,
+            array_position(input_array, val) AS ord
+        FROM unnest(input_array) val
+        WHERE val IS NOT NULL
+    ),
+    dedup AS (
+        SELECT DISTINCT ON (norm)
+            original,
+            norm,
+            ord
+        FROM normalized
+        ORDER BY norm, ord
+    ),
+    filtered AS (
+        SELECT original, ord
+        FROM dedup
+        WHERE exclude_array IS NULL
+           OR NOT EXISTS (
+               SELECT 1
+               FROM unnest(exclude_array) e
+               WHERE e IS NOT NULL
+                AND (lower(trim(e)) = norm OR norm LIKE '%' || lower(trim(e)) || '%')
+           )
+    )
+    SELECT array_agg(original ORDER BY ord)
+    FROM filtered;
+$$;


### PR DESCRIPTION
## Summary
- add legacy migration placeholders for versions present in remote history but missing locally (`20241008210613`, `20241206143825`)
- restore migration file `20251120150626_fix_get_distinct_or_exclude_from_array.sql` that exists in remote history
- keep migration version reconciliation stable so QA `supabase db push --include-all` no longer fails on missing remote versions

## Verification
- verified required legacy versions are present in `supabase/migrations`
- verified migration versions remain unique (no duplicate timestamps)