### PR TITLE
fix: correct IMAP-to-SMTP host/port mapping for email campaigns

### DIFF
--- a/supabase/functions/email-campaigns/index.ts
+++ b/supabase/functions/email-campaigns/index.ts
@@ -614,20 +614,23 @@ async function getUserMiningSources(
 async function guessCustomSmtpHost(email: string) {
   const detected = await new IMAPSettingsDetector.default().detect(email);
   const host = (detected?.host || "") as string;
+
+  let smtpHost: string;
   if (host.startsWith("imap.")) {
-    return {
-      host: host.replace(/^imap\./, "smtp."),
-      port: 587,
-      secure: false,
-    };
+    smtpHost = host.replace(/^imap\./, "mail.");
+  } else if (host.startsWith("mail.")) {
+    smtpHost = host;
+  } else {
+    const domain = email.split("@")[1];
+    smtpHost = `smtp.${domain}`;
   }
 
-  const domain = email.split("@")[1];
-  return {
-    host: `smtp.${domain}`,
-    port: 587,
-    secure: false,
-  };
+  // Map IMAP port to SMTP port: 993 → 465 (SSL), otherwise → 587 (TLS/STARTTLS)
+  const imapPort = detected?.port ?? 143;
+  const smtpPort = imapPort === 993 ? 465 : 587;
+  const smtpSecure = imapPort === 993;
+
+  return { host: smtpHost, port: smtpPort, secure: smtpSecure };
 }
 
 async function buildUserTransport(


### PR DESCRIPTION
## Summary
- Fix `guessCustomSmtpHost` to correctly map IMAP detected settings to SMTP
- `imap.*` hosts → `mail.*` (not `smtp.*`)
- `mail.*` hosts → kept as-is (was falling through to `smtp.{domain}`)
- SMTP port/secure derived from IMAP port: 993→465/SSL, 143→587/TLS

## Problem
IMAP sources were incorrectly marked as "unavailable" in email campaigns because SMTP verification failed. The function was hardcoding port 587 and `secure: false` for all custom IMAP sources, and mapping hosts incorrectly.

## Test case
`mail.agircollectif.org:993` (IMAP/TLS) → now correctly maps to `mail.agircollectif.org:465` (SMTP/SSL)