### PR TITLE
feat(contacts): auto-show columns with values and always display phone/social icons

### DIFF
--- a/frontend/src/components/mining/ContactInformationSidebar.vue
+++ b/frontend/src/components/mining/ContactInformationSidebar.vue
@@ -69,6 +69,13 @@
           >
             <social-links-and-phones :social-links="contact.same_as" />
           </div>
+          <div class="flex items-center gap-1 pt-1">
+            <span class="font-medium">{{ $t('contact.tags') }}</span>
+            <i
+              v-tooltip.top="$t('categorize_contacts')"
+              class="pi pi-info-circle text-surface-400 cursor-help text-sm"
+            />
+          </div>
           <div
             v-if="!editingContact && contact.tags?.length"
             class="flex pt-1 space-x-2"
@@ -81,11 +88,7 @@
             />
           </div>
           <div v-else-if="editingContact" class="pt-1">
-            <Chips
-              v-model="contactEditTags"
-              :placeholder="$t('contact.tags_placeholder')"
-              class="w-full"
-            />
+            <Chips v-model="contactEditTags" class="w-full" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/mining/table/MiningTable.vue
+++ b/frontend/src/components/mining/table/MiningTable.vue
@@ -352,17 +352,14 @@
 
             <!-- RIGHT -->
             <div
-              v-if="
-                showSocialLinksAndPhones(data) &&
-                (columnVisibility.same_as || columnVisibility.telephone)
-              "
+              v-if="showSocialLinksAndPhones(data)"
               class="flex md:hidden gap-2 flex-shrink-0"
             >
               <social-links-and-phones
                 :social-links="data.same_as"
-                :show-social-links="columnVisibility.same_as"
+                :show-social-links="true"
                 :phones="data.telephone"
-                :show-phones="columnVisibility.telephone"
+                :show-phones="true"
                 :small="true"
               />
             </div>
@@ -370,17 +367,14 @@
 
           <div class="flex items-center gap-2 flex-shrink-0">
             <div
-              v-if="
-                showSocialLinksAndPhones(data) &&
-                (columnVisibility.same_as || columnVisibility.telephone)
-              "
+              v-if="showSocialLinksAndPhones(data)"
               class="hidden md:flex gap-2 flex-shrink-0"
             >
               <social-links-and-phones
                 :social-links="data.same_as"
-                :show-social-links="columnVisibility.same_as"
+                :show-social-links="true"
                 :phones="data.telephone"
-                :show-phones="columnVisibility.telephone"
+                :show-phones="true"
                 :small="true"
               />
             </div>
@@ -1489,19 +1483,7 @@ onBeforeMount(() => {
 });
 onNuxtReady(() => {
   $screenStore.init();
-  $contactsStore.visibleColumns = [
-    'contacts',
-    'name',
-    'same_as',
-    'telephone',
-    'image',
-    'location',
-    ...(origin === 'contacts' && $screenStore.width > 550
-      ? ['temperature']
-      : []),
-    ...($screenStore.width > 700 ? ['tags'] : []),
-    ...($screenStore.width > 800 ? ['status'] : []),
-  ];
+  $contactsStore.visibleColumns = getDefaultVisibleColumns();
 });
 
 onBeforeMount(() => {
@@ -1510,7 +1492,6 @@ onBeforeMount(() => {
 onNuxtReady(async () => {
   $screenStore.init();
   $filtersStore.initializeTableFilters(origin);
-  $contactsStore.initializeVisibleColumns(getDefaultVisibleColumns(), origin);
 
   if (contactsLoadingStrategy.value === 'immediate') {
     await loadContactsData();
@@ -1518,6 +1499,13 @@ onNuxtReady(async () => {
     isLoading.value = false;
     scheduleIdleContactsPrefetch();
   }
+
+  $contactsStore.initializeVisibleColumns(
+    getDefaultVisibleColumns(),
+    origin,
+    $contactsStore.contactsList,
+  );
+
   const locationsToNormalize = $contactsStore.getLocationsToNormalize();
 
   if (origin === 'mine' && locationsToNormalize.length > 0) {

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -253,9 +253,24 @@ export const useContactsStore = defineStore('contacts-store', () => {
     return [...new Set(locations)];
   }
 
+  function getAutoVisibleColumns(contacts: Contact[]): string[] {
+    const columns = new Set<string>(['contacts']);
+
+    for (const contact of contacts) {
+      if (contact.name) columns.add('name');
+      if (contact.telephone?.length) columns.add('telephone');
+      if (contact.location) columns.add('location');
+      if (contact.works_for) columns.add('works_for');
+      if (contact.job_title) columns.add('job_title');
+    }
+
+    return [...columns];
+  }
+
   function initializeVisibleColumns(
     defaultColumns: string[],
     origin: TableOrigin,
+    contacts?: Contact[],
   ) {
     const userId = getCurrentUserId();
     if (!userId || !import.meta.client) {
@@ -268,7 +283,11 @@ export const useContactsStore = defineStore('contacts-store', () => {
     const storedColumns = localStorage.getItem(key);
 
     if (!storedColumns) {
-      visibleColumns.value = sanitizeVisibleColumns(defaultColumns);
+      if (contacts && contacts.length > 0) {
+        visibleColumns.value = sanitizeVisibleColumns(getAutoVisibleColumns(contacts));
+      } else {
+        visibleColumns.value = sanitizeVisibleColumns(defaultColumns);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add auto-visible columns detection based on whitelist (name, telephone, location, works_for, job_title)
- Always show phone and social links icons in name column, regardless of column selection
- Add info tooltip for tags in sidebar with (i) icon, remove placeholder from chips