### PR TITLE
fix: add surrogate id column to private.mining_sources

### DIFF
--- a/supabase/functions/mining-sources/deno.lock
+++ b/supabase/functions/mining-sources/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "4",
   "specifiers": {
+    "npm:@types/node@*": "22.12.0",
     "npm:simple-oauth2@5.1.0": "5.1.0"
   },
   "npm": {
@@ -45,6 +46,12 @@
     "@sideway/pinpoint@2.0.0": {
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
@@ -72,7 +79,21 @@
         "debug",
         "joi"
       ]
+    },
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     }
+  },
+  "redirects": {
+    "https://esm.sh/@supabase/node-fetch@^2.6.14?target=denonext": "https://esm.sh/@supabase/node-fetch@2.6.15?target=denonext",
+    "https://esm.sh/@types/ws@~8.18.1/index.d.mts": "https://esm.sh/@types/ws@8.18.1/index.d.mts",
+    "https://esm.sh/bufferutil@^4.0.1?target=denonext": "https://esm.sh/bufferutil@4.1.0?target=denonext",
+    "https://esm.sh/node-gyp-build@^4.3.0?target=denonext": "https://esm.sh/node-gyp-build@4.8.4?target=denonext",
+    "https://esm.sh/tr46@~0.0.3?target=denonext": "https://esm.sh/tr46@0.0.3?target=denonext",
+    "https://esm.sh/utf-8-validate@%3E=5.0.2?target=denonext": "https://esm.sh/utf-8-validate@6.0.6?target=denonext",
+    "https://esm.sh/webidl-conversions@^3.0.0?target=denonext": "https://esm.sh/webidl-conversions@3.0.1?target=denonext",
+    "https://esm.sh/whatwg-url@^5.0.0?target=denonext": "https://esm.sh/whatwg-url@5.0.0?target=denonext",
+    "https://esm.sh/ws@^8.14.2?target=denonext": "https://esm.sh/ws@8.20.0?target=denonext"
   },
   "remote": {
     "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
@@ -122,8 +143,30 @@
     "https://deno.land/x/zod@v3.25/mod.ts": "ec6e2b1255c1a350b80188f97bd0a6bac45801bb46fc48f50b9763aa66046039",
     "https://deno.land/x/zod@v3.25/standard-schema.ts": "4abb2e7bd784fb95d219584673971bb317e74fb4fd0c74c196b558ba46df4456",
     "https://deno.land/x/zod@v3.25/types.ts": "cfdd77407d4b06e79bd63e9cfdb6091489aeb5f432d03a68c0531c1965d001fb",
+    "https://esm.sh/@supabase/auth-js@2.65.0/denonext/auth-js.mjs": "b0dae93271b199b26f7990e9091ecd2556125f2bfe1c9a443893bf0519908858",
+    "https://esm.sh/@supabase/functions-js@2.4.1/denonext/functions-js.mjs": "0dfa81270bba8ae5af371b273a564203b4625b3a18e70774235b0b46ef40d940",
+    "https://esm.sh/@supabase/node-fetch@2.6.15/denonext/node-fetch.mjs": "0bae9052231f4f6dbccc7234d05ea96923dbf967be12f402764580b6bf9f713d",
+    "https://esm.sh/@supabase/node-fetch@2.6.15?target=denonext": "4d28c4ad97328403184353f68434f2b6973971507919e9150297413664919cf3",
+    "https://esm.sh/@supabase/postgrest-js@1.15.8/denonext/postgrest-js.mjs": "e38ab1fbd1d7ed325e3ddc20c72001d3653151c3d3be3455d682b141321a345d",
+    "https://esm.sh/@supabase/realtime-js@2.10.2/denonext/realtime-js.mjs": "3a5a350e881736135ec1bd8c4361c96edeb647d3c56be7cf3a68eddfaf3ce242",
+    "https://esm.sh/@supabase/storage-js@2.7.0/denonext/storage-js.mjs": "e831f9ac91b49f5e7026879efa7b61a360bc1c4b9fa2dd9890432c2e877a6611",
     "https://esm.sh/@supabase/supabase-js@2.45.3": "120c64e8b607f0c23cfaa2b418b51c4d235edb1e6f40087a080b67a83c6f64b8",
-    "https://esm.sh/hono@4.7.4": "174d520e05dd0a3a1405b1435ee8a8cfe08b16ea80a8363879a88b8a6ff14f69"
+    "https://esm.sh/@supabase/supabase-js@2.45.3/denonext/supabase-js.mjs": "412befe6cbb987ad20cb504f6c0e96d07fe20bf6ab64c4a631b63d3e2ff478a7",
+    "https://esm.sh/bufferutil@4.1.0/denonext/bufferutil.mjs": "9b6e81087bdc57848ad1de1f8618ebbace98ebd9ff6cab51260b48c2a045a9c9",
+    "https://esm.sh/bufferutil@4.1.0?target=denonext": "aaa2a112199593ccc40da1aedf5124779862ea166afb0a8529f04f907001428a",
+    "https://esm.sh/hono@4.7.4": "174d520e05dd0a3a1405b1435ee8a8cfe08b16ea80a8363879a88b8a6ff14f69",
+    "https://esm.sh/node-gyp-build@4.8.4/denonext/node-gyp-build.mjs": "9a86f2d044fc77bd60aaa3d697c2ba1b818da5fb1b9aaeedec59a40b8e908803",
+    "https://esm.sh/node-gyp-build@4.8.4?target=denonext": "261a6cedf1fdbf159798141ba1e2311ac1510682c5c8b55dacc8cf5fdee4aa06",
+    "https://esm.sh/tr46@0.0.3/denonext/tr46.mjs": "5753ec0a99414f4055f0c1f97691100f13d88e48a8443b00aebb90a512785fa2",
+    "https://esm.sh/tr46@0.0.3?target=denonext": "19cb9be0f0d418a0c3abb81f2df31f080e9540a04e43b0f699bce1149cba0cbb",
+    "https://esm.sh/utf-8-validate@6.0.6/denonext/utf-8-validate.mjs": "4a41983aa887625615f52a52b53c223d8f16c74e52a6bd41b2c361894c07f878",
+    "https://esm.sh/utf-8-validate@6.0.6?target=denonext": "8afa4e097093160323f232f971ca61474d22ccafdac8025e4e4f66ab4e07b2c4",
+    "https://esm.sh/webidl-conversions@3.0.1/denonext/webidl-conversions.mjs": "238cd0743827707cbc1c2d7c2cf1027dbc536fb53ec9a3fde0ff8026a3ac5385",
+    "https://esm.sh/webidl-conversions@3.0.1?target=denonext": "4e20318d50528084616c79d7b3f6e7f0fe7b6d09013bd01b3974d7448d767e29",
+    "https://esm.sh/whatwg-url@5.0.0/denonext/whatwg-url.mjs": "29b16d74ee72624c915745bbd25b617cfd2248c6af0f5120d131e232a9a9af79",
+    "https://esm.sh/whatwg-url@5.0.0?target=denonext": "f001a2cadf81312d214ca330033f474e74d81a003e21e8c5d70a1f46dc97b02d",
+    "https://esm.sh/ws@8.20.0/denonext/ws.mjs": "8f99f7c486b2200e4fcf9449bdc4f2cd612edb2db751b7e8e7ebb5c0a2338d31",
+    "https://esm.sh/ws@8.20.0?target=denonext": "effaa9bb90113d428c29c9b80d5783c9d0717da4ade0a31590a439fd2dac4509"
   },
   "workspace": {
     "dependencies": [

--- a/supabase/functions/mining-sources/index.test.ts
+++ b/supabase/functions/mining-sources/index.test.ts
@@ -1,5 +1,55 @@
-import { assertEquals, assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.3";
 import { createSchema, authorizeSchema, callbackQuerySchema } from "./schemas.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ??
+  "http://127.0.0.1:54321";
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get(
+  "SUPABASE_SERVICE_ROLE_KEY",
+) ?? "";
+
+function getAdmin() {
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY env var is required to run this test",
+    );
+  }
+  // Disable auto-refresh: this is a service-role admin client used only for
+  // a one-off schema introspection query, no session to keep alive. Without
+  // this, supabase-auth-js starts a setInterval that leaks past the test.
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+Deno.test(
+  "private.mining_sources has an id column (regression for 'column mining_sources.id does not exist')",
+  async () => {
+    const admin = getAdmin();
+
+    // This is the exact query the edge function runs at
+    // supabase/functions/mining-sources/index.ts:177 to look up the source
+    // id before calling create_smtp_sender_for_oauth. If `id` is missing,
+    // the query errors and the SMTP twin is silently skipped.
+    const { error } = await admin
+      .schema("private")
+      .from("mining_sources")
+      .select("id")
+      .limit(1);
+
+    assert(
+      error === null,
+      `Expected no error selecting 'id' from private.mining_sources, got: ${
+        error?.message ?? "null"
+      }. ` +
+        "The edge function relies on this column to look up the source id " +
+        "before creating the SMTP twin sender after OAuth callback.",
+    );
+  },
+);
 
 Deno.test("createSchema rejects invalid provider", () => {
   const result = createSchema.safeParse({

--- a/supabase/migrations/20260605155137_add_id_to_mining_sources.sql
+++ b/supabase/migrations/20260605155137_add_id_to_mining_sources.sql
@@ -1,0 +1,46 @@
+-- Add surrogate id to private.mining_sources
+--
+-- The mining_sources table has been operating with a composite primary key
+-- (email, user_id) since init, but several code paths assume a stable
+-- per-row UUID column called `id`:
+--
+--   - supabase/functions/mining-sources/index.ts: select("id") on the
+--     callback to look up the source before creating the SMTP twin
+--   - private.smtp_senders.mining_source_id: REFERENCES private.mining_sources(id)
+--   - private.create_smtp_sender_for_oauth: takes _mining_source_id UUID
+--
+-- The column was never created, so the callback flow logs:
+--   "Failed to get mining source ID for SMTP twin"
+--   "column mining_sources.id does not exist"
+-- and silently skips SMTP twin creation.
+--
+-- This migration is idempotent (uses IF NOT EXISTS guards) so it is safe
+-- to run on environments that already have the column.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'private'
+      AND table_name = 'mining_sources'
+      AND column_name = 'id'
+  ) THEN
+    ALTER TABLE private.mining_sources
+      ADD COLUMN id UUID DEFAULT gen_random_uuid() NOT NULL;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'private.mining_sources'::regclass
+      AND contype = 'u'
+      AND conname = 'mining_sources_id_key'
+  ) THEN
+    ALTER TABLE private.mining_sources
+      ADD CONSTRAINT mining_sources_id_key UNIQUE (id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Problem

The OAuth callback in the mining-sources edge function logs:

```
"Failed to get mining source ID for SMTP twin"
"column mining_sources.id does not exist"
```

and silently skips SMTP twin creation. The `private.mining_sources` table was created without an `id` column, but several code paths assume one exists:

- `mining-sources/index.ts` — `select("id")` on the callback to look up the source before creating the SMTP twin
- `smtp_senders.mining_source_id` — `REFERENCES private.mining_sources(id)`
- `create_smtp_sender_for_oauth` — takes `_mining_source_id UUID`

## Fix

New migration `20260605155137_add_id_to_mining_sources.sql`:

- Adds a `UUID` `id` column with `gen_random_uuid()` default
- Adds a `UNIQUE` constraint on the new column
- Keeps the existing `(email, user_id)` primary key
- Idempotent via `information_schema` / `pg_constraint` checks — safe to run on any environment

New Deno regression test in `mining-sources/index.test.ts` that selects the `id` column. Fails before the migration, passes after.

## TDD

- **RED**: test failed with `column mining_sources.id does not exist`
- **GREEN**: after applying the migration, all 40 Deno tests pass
- **Idempotency**: re-running the migration is a no-op
- **FK**: the `add_smtp_senders` migration that was previously marked "skipped: pre-existing broken" now applies cleanly, creating `smtp_senders_mining_source_id_fkey → private.mining_sources(id)`

## Verification

```
$ deno test --allow-net --allow-env
ok | 40 passed | 0 failed

$ npm run test:unit (backend)
Tests: 585 passed, 585 total

$ npm run test:unit (emails-fetcher)
Tests: 33 passed, 33 total
```

## Risk

- `ADD COLUMN ... NOT NULL DEFAULT gen_random_uuid()` is a metadata-only operation in Postgres 11+ (no table rewrite)
- Idempotent migration: safe on any environment regardless of whether the column already exists
- Zero application risk: all consumers already assume `id` exists

## Deployment

After merging, run the Supabase migration deploy to apply the new SQL on QA.