### PR TITLE
fix(supabase): make migrations idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ logger.error("Operation failed", { error: error.message });
 - Branch naming: `feat/`, `fix/`, `docs/` prefixes
 - Commit messages: imperative mood, lowercase first letter
 - Run `npm run precommit:check` before committing (husky + lint-staged)
+- PR descriptions: keep them clear and short. Lead with one-line summary, list key changes as bullets, mention how it was tested. Skip verbose background sections unless the context is non-obvious.
 - **IMPORTANT - Ask User Before Git Operations:**
   - Ask before creating worktrees (using-git-worktrees skill)
   - Ask before committing changes

--- a/supabase/migrations/20260407120500_add_gateway_names_to_campaign_overview.sql
+++ b/supabase/migrations/20260407120500_add_gateway_names_to_campaign_overview.sql
@@ -1,7 +1,10 @@
 -- Add gateway_names to SMS campaign overview by joining selected_gateway_ids with sms_fleet_gateways
 -- This allows the frontend to display which specific gateways were used instead of just "fleet"
 
-CREATE OR REPLACE FUNCTION public.get_sms_campaigns_overview()
+DROP FUNCTION IF EXISTS public.get_sms_campaigns_overview();
+DROP FUNCTION IF EXISTS public.get_unified_campaigns_overview();
+
+CREATE FUNCTION public.get_sms_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   sender_name TEXT,
@@ -58,7 +61,7 @@ END;
 $$;
 
 -- Also update the unified overview to include gateway_names
-CREATE OR REPLACE FUNCTION public.get_unified_campaigns_overview()
+CREATE FUNCTION public.get_unified_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   channel TEXT,

--- a/supabase/migrations/20260418100000_add_message_template_to_campaign_overview.sql
+++ b/supabase/migrations/20260418100000_add_message_template_to_campaign_overview.sql
@@ -1,8 +1,11 @@
 -- Add message_template to SMS campaign overview functions
 -- This allows the frontend to display the SMS content preview
 
+DROP FUNCTION IF EXISTS public.get_sms_campaigns_overview();
+DROP FUNCTION IF EXISTS public.get_unified_campaigns_overview();
+
 -- Update get_sms_campaigns_overview to include message_template
-CREATE OR REPLACE FUNCTION public.get_sms_campaigns_overview()
+CREATE FUNCTION public.get_sms_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   sender_name TEXT,
@@ -61,7 +64,7 @@ END;
 $$;
 
 -- Update get_unified_campaigns_overview to include message_template
-CREATE OR REPLACE FUNCTION public.get_unified_campaigns_overview()
+CREATE FUNCTION public.get_unified_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   channel TEXT,

--- a/supabase/migrations/20260531120000_add_whatsapp_channel.sql
+++ b/supabase/migrations/20260531120000_add_whatsapp_channel.sql
@@ -44,7 +44,9 @@ CREATE INDEX IF NOT EXISTS idx_sms_campaign_recipients_provider_msg_id
   WHERE provider_message_id IS NOT NULL;
 
 -- 8. Update get_sms_campaigns_overview to include channel + whatsapp metrics
-CREATE OR REPLACE FUNCTION public.get_sms_campaigns_overview()
+DROP FUNCTION IF EXISTS public.get_sms_campaigns_overview();
+DROP FUNCTION IF EXISTS public.get_unified_campaigns_overview();
+CREATE FUNCTION public.get_sms_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   sender_name TEXT,
@@ -109,7 +111,7 @@ END;
 $$;
 
 -- 9. Update get_unified_campaigns_overview to use sms_campaigns.channel + whatsapp metrics
-CREATE OR REPLACE FUNCTION public.get_unified_campaigns_overview()
+CREATE FUNCTION public.get_unified_campaigns_overview()
 RETURNS TABLE (
   id UUID,
   channel TEXT,


### PR DESCRIPTION
Unblocks the leadminer.io QA migration deploy. Some migrations fail on PG 15 when state is partially pre-applied: `CREATE OR REPLACE FUNCTION` can't change `RETURNS TABLE` columns, and several DDL statements aren't idempotent. Wraps them in patterns that no-op cleanly when the state already exists.

## Changes

- `supabase/migrations/20260407120500_add_gateway_names_to_campaign_overview.sql`: replace `CREATE OR REPLACE` with `DROP FUNCTION IF EXISTS` + `CREATE` for both `get_sms_campaigns_overview` and `get_unified_campaigns_overview`.
- `supabase/migrations/20260418100000_add_message_template_to_campaign_overview.sql`: same fix.
- `supabase/migrations/20260531120000_add_whatsapp_channel.sql`: same fix.
- `supabase/migrations/20260512160000_add_google_contacts_fetch_to_task_type_enum.sql`: `ADD VALUE IF NOT EXISTS`.
- `supabase/migrations/20260530120000_add_smtp_senders.sql`: `CREATE INDEX IF NOT EXISTS`, `DROP POLICY IF EXISTS` + `CREATE POLICY`.
- `supabase/migrations/20260531000000_fix_remaining_search_path_warnings.sql`: wrap bare `ALTER FUNCTION ... SET search_path` in `DO $$ ... EXCEPTION WHEN undefined_function THEN NULL; END $$;` blocks (matches existing style in the same file).
- `supabase/migrations/20260603000001_create_smtp_sender_for_oauth.sql`: `CREATE OR REPLACE FUNCTION`.
- `AGENTS.md`: add PR description guideline.

## Testing

Verified locally against `supabase_db_leadminer` (PG 15.8). Pre-applied the schema state to simulate QA, then ran each fixed migration with `psql -v ON_ERROR_STOP=1 -f`. All seven migrations apply cleanly with the expected NOTICEs ("enum label already exists, skipping" etc.).