### PR TITLE
chore: prevent AI plan files from leaking to remote

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
+bash ./scripts/check-forbidden-paths.sh
 npm run precommit:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,10 @@ logger.error("Operation failed", { error: error.message });
   - Ask before pushing to remote
   - Ask before creating pull requests
   - Never automatically commit or push without user approval
+- **PRs that close an issue must include `Resolves #<issue-number>`** (or
+  `Closes #<issue-number>`, `Fixes #<issue-number>`) in the PR body. This
+  auto-closes the issue when the PR is merged. PRs that don't close a
+  specific issue (e.g. maintenance, refactors) do not need the line.
 
 ### Vue/Frontend Patterns
 
@@ -385,13 +389,23 @@ If you see a 404 for a newly added API endpoint (e.g., `/api/smtp-senders/regene
 - **The frontend image is shared between QA and Prod** — Both pull `ankabootorg/leadminer-frontend:latest`. This means a prod deploy could accidentally get a QA-tested frontend if the image was overwritten.
 - **leadminer-commercial is merged at deploy time** — The integration script copies billing code into the repo before building. If commercial has breaking changes, the build will fail.
 
-## Planning Documents
+### Planning Documents
 
-### docs/plans Directory
+Local planning documents (opencode + superpowers workflow) must NEVER be
+committed or pushed to remote. The following paths are blocked by both
+`.gitignore` and the husky `pre-commit` guard (`scripts/check-forbidden-paths.sh`):
 
-Local planning documents for development reference. **Do NOT commit or push to remote.**
+- `docs/plans/`
+- `.opencode/` (entire directory)
+- `.agents/` (entire directory)
+- `skills-lock.json`
 
-When creating: `docs/plans/YYYY-MM-DD-<feature-name>.md`. Delete when feature is complete.
+If the pre-commit hook rejects your commit, run `git restore --staged <path>`
+to unstage the forbidden file and retry. The hook never silently passes —
+it either succeeds or exits non-zero with a clear message.
+
+When creating: `docs/plans/YYYY-MM-DD-<feature-name>.md` (kept local,
+gitignored). Delete when the feature is complete.
 
 ## Quality Assurance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,7 +389,7 @@ If you see a 404 for a newly added API endpoint (e.g., `/api/smtp-senders/regene
 - **The frontend image is shared between QA and Prod** — Both pull `ankabootorg/leadminer-frontend:latest`. This means a prod deploy could accidentally get a QA-tested frontend if the image was overwritten.
 - **leadminer-commercial is merged at deploy time** — The integration script copies billing code into the repo before building. If commercial has breaking changes, the build will fail.
 
-### Planning Documents
+## Planning Documents
 
 Local planning documents (opencode + superpowers workflow) must NEVER be
 committed or pushed to remote. The following paths are blocked by both

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prettier:fix": "npm run prettier:fix --prefix ./backend && npm run prettier:fix --prefix ./frontend && npm run prettier:fix --prefix ./micro-services/emails-fetcher",
     "prepare": "husky",
     "precommit:check": "lint-staged",
+    "precommit:check:plans": "bash ./scripts/check-forbidden-paths.sh",
     "prepush:check": "bash ./scripts/prepush-ci-check.sh"
   },
   "author": "ankaboot",

--- a/scripts/check-forbidden-paths.sh
+++ b/scripts/check-forbidden-paths.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# Pre-commit guard: reject staging of AI-assistant artifacts.
+# See AGENTS.md -> "Planning Documents" for the rule.
+# Exit non-zero on violation; print clear remediation.
+
+set -e
+
+FORBIDDEN_PATTERNS='^(docs/plans/|\.opencode/|\.agents/|skills-lock\.json$)'
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+violations=$(printf '%s\n' "$staged" | grep -E "$FORBIDDEN_PATTERNS" || true)
+
+if [ -n "$violations" ]; then
+  echo ""
+  echo "Refusing to commit: AI-assistant artifacts detected in staged files."
+  echo ""
+  echo "The following paths must not be committed (see AGENTS.md -> Planning Documents):"
+  printf '%s\n' "$violations" | sed 's/^/  - /'
+  echo ""
+  echo "To unstage and continue, run:"
+  echo "  git restore --staged <path>"
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds defense-in-depth to stop `docs/plans/`, `.opencode/`, `.agents/`, and `skills-lock.json` from ever being committed to the leadminer repo.

The repo's `.gitignore` already blocks these paths, but a developer can override with `git add -f`. The new local pre-commit guard catches that case before a commit leaves the developer's machine.

## Changes

- **`scripts/check-forbidden-paths.sh`** (new) — POSIX-sh guard that scans staged files and exits non-zero on violation, with a clear error message and `git restore --staged <path>` hint.
- **`.husky/pre-commit`** — runs the guard before `lint-staged`. `set -e` is added so the hook's exit code reflects the guard's failure, not `lint-staged`'s success.
- **`package.json`** — exposes `npm run precommit:check:plans` for manual runs.
- **`AGENTS.md`**:
  - Expands the **Planning Documents** section to list all four forbidden paths (was just `docs/plans/` before) and reference the new guard.
  - Adds a **Git Conventions** rule that PRs closing an issue must include `Resolves #<issue-number>` (or `Closes`/`Fixes`) so GitHub auto-closes the issue on merge.

## Commits

```
8f19a1a3 docs(agents): restore ## heading on Planning Documents section
62d4183c docs(agents): list full set of forbidden AI plan paths and PR auto-close rule
2778fa7f chore(scripts): expose precommit:check:plans npm script
5961bb83 chore(husky): run forbidden-paths guard before lint-staged
62738ac1 chore(tools): add pre-commit guard for AI-assistant artifacts
```

## Verification

- `git ls-files` on the branch returns no plan files.
- `git check-ignore -v` confirms all four patterns block correctly (including nested paths).
- End-to-end: `git add -f docs/plans/test.md && bash .husky/pre-commit` exits 1 with the expected error and a `git restore --staged` hint.

## Notes

- The 3 leaked plan files in `leadminer-commercial` PR #113 are cleaned up in a separate, related PR.
- A matching hardening PR is being opened on `leadminer-commercial` to bring its `.gitignore` and hook up to the same standard.