### PR TITLE
fix(supabase): tolerate owner-mismatch on smtp_senders and whatsapp_sessions

### DIFF
--- a/supabase/migrations/20260530120000_add_smtp_senders.sql
+++ b/supabase/migrations/20260530120000_add_smtp_senders.sql
@@ -18,12 +18,20 @@ CREATE TABLE IF NOT EXISTS private.smtp_senders (
    UNIQUE(user_id, email)
  );
 
-CREATE INDEX IF NOT EXISTS idx_smtp_senders_user_id ON private.smtp_senders(user_id);
+-- CREATE INDEX / CREATE POLICY on an existing table require ownership.
+-- On QA the table may have been pre-applied by a role that doesn't match
+-- the migration runner, so these no-op cleanly when we lack privilege.
+DO $$
+BEGIN
+  CREATE INDEX idx_smtp_senders_user_id ON private.smtp_senders(user_id);
+EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL;
+END $$;
 
 ALTER TABLE private.smtp_senders ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "Users can manage own smtp_senders" ON private.smtp_senders;
-CREATE POLICY "Users can manage own smtp_senders"
-  ON private.smtp_senders
-  USING (auth.uid() = user_id)
-  WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+  EXECUTE 'DROP POLICY IF EXISTS "Users can manage own smtp_senders" ON private.smtp_senders';
+  EXECUTE 'CREATE POLICY "Users can manage own smtp_senders" ON private.smtp_senders USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id)';
+EXCEPTION WHEN insufficient_privilege THEN NULL;
+END $$;

--- a/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
+++ b/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
@@ -32,33 +32,21 @@ CREATE TABLE IF NOT EXISTS private.whatsapp_sessions (
 );
 
 -- Indexes
-CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_user_id ON private.whatsapp_sessions(user_id);
-CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_status ON private.whatsapp_sessions(status);
-CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_active ON private.whatsapp_sessions(is_active);
+-- CREATE INDEX / CREATE POLICY on an existing table require ownership.
+-- On QA the table may have been pre-applied by a role that doesn't match
+-- the migration runner, so these no-op cleanly when we lack privilege.
+DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_user_id ON private.whatsapp_sessions(user_id); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
+DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_status ON private.whatsapp_sessions(status); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
+DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_active ON private.whatsapp_sessions(is_active); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
 
 -- Enable RLS
 ALTER TABLE private.whatsapp_sessions ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for whatsapp_sessions
-DROP POLICY IF EXISTS "Users can view own whatsapp sessions" ON private.whatsapp_sessions;
-CREATE POLICY "Users can view own whatsapp sessions"
-  ON private.whatsapp_sessions FOR SELECT
-  USING (auth.uid() = user_id);
-
-DROP POLICY IF EXISTS "Users can insert own whatsapp sessions" ON private.whatsapp_sessions;
-CREATE POLICY "Users can insert own whatsapp sessions"
-  ON private.whatsapp_sessions FOR INSERT
-  WITH CHECK (auth.uid() = user_id);
-
-DROP POLICY IF EXISTS "Users can update own whatsapp sessions" ON private.whatsapp_sessions;
-CREATE POLICY "Users can update own whatsapp sessions"
-  ON private.whatsapp_sessions FOR UPDATE
-  USING (auth.uid() = user_id);
-
-DROP POLICY IF EXISTS "Users can delete own whatsapp sessions" ON private.whatsapp_sessions;
-CREATE POLICY "Users can delete own whatsapp sessions"
-  ON private.whatsapp_sessions FOR DELETE
-  USING (auth.uid() = user_id);
+DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can view own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can view own whatsapp sessions" ON private.whatsapp_sessions FOR SELECT USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
+DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can insert own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can insert own whatsapp sessions" ON private.whatsapp_sessions FOR INSERT WITH CHECK (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
+DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can update own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can update own whatsapp sessions" ON private.whatsapp_sessions FOR UPDATE USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
+DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can delete own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can delete own whatsapp sessions" ON private.whatsapp_sessions FOR DELETE USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
 
 -- Trigger to automatically update updated_at
 CREATE OR REPLACE FUNCTION private.update_whatsapp_session_updated_at()


### PR DESCRIPTION
Continues unblocking the leadminer.io QA migration deploy. PR #2836 fixed the duplicate-object errors; this fixes the next failure mode — `must be owner of table` — that the deploy hits once past the idempotency fixes.

## Context

On QA, `private.smtp_senders` and `private.whatsapp_sessions` were pre-applied by a role that doesn't match the migration runner. `CREATE INDEX` and `CREATE POLICY` on an existing table require ownership, so the runner hits `42501 insufficient_privilege` before `IF NOT EXISTS` can even run.

## Changes

- `supabase/migrations/20260530120000_add_smtp_senders.sql`: wrap `CREATE INDEX` and `CREATE POLICY` in `DO $$ ... EXCEPTION WHEN insufficient_privilege OR duplicate_* THEN NULL; END $$;`.
- `supabase/migrations/20260601000000_add_whatsapp_gateway.sql`: same pattern for the 3 `CREATE INDEX` and 4 `CREATE POLICY` statements on `whatsapp_sessions`.

## Trade-off

When the runner isn't the owner, the index/policy may be missing on QA after the migration. Acceptable because whoever pre-applied the table should have created them too; on a fresh env the migration applies correctly. Documented inline.

## Testing

Verified locally against `supabase_db_leadminer` (PG 15.8). Ran the fixed migrations against a pre-applied state — apply cleanly. Local `postgres` is superuser so it bypasses ownership checks, but the DO blocks also catch `duplicate_object`, and the `EXCEPTION WHEN insufficient_privilege` condition matches the error from the failed QA run `#27030339920`.