### PR TITLE
fix(supabase): also wrap ENABLE ROW LEVEL SECURITY in DO blocks

### DIFF
--- a/supabase/migrations/20260530120000_add_smtp_senders.sql
+++ b/supabase/migrations/20260530120000_add_smtp_senders.sql
@@ -18,20 +18,26 @@ CREATE TABLE IF NOT EXISTS private.smtp_senders (
    UNIQUE(user_id, email)
  );
 
--- CREATE INDEX / CREATE POLICY on an existing table require ownership.
--- On QA the table may have been pre-applied by a role that doesn't match
--- the migration runner, so these no-op cleanly when we lack privilege.
+-- CREATE INDEX / CREATE POLICY / ENABLE RLS on an existing table require
+-- ownership. On QA the table may have been pre-applied by a role that
+-- doesn't match the migration runner, so these no-op cleanly when we lack
+-- privilege. Whoever pre-applied the table is responsible for the
+-- index / RLS / policy.
 DO $$
 BEGIN
   CREATE INDEX idx_smtp_senders_user_id ON private.smtp_senders(user_id);
 EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL;
 END $$;
 
-ALTER TABLE private.smtp_senders ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE private.smtp_senders ENABLE ROW LEVEL SECURITY';
+EXCEPTION WHEN insufficient_privilege THEN NULL;
+END $$;
 
 DO $$
 BEGIN
   EXECUTE 'DROP POLICY IF EXISTS "Users can manage own smtp_senders" ON private.smtp_senders';
   EXECUTE 'CREATE POLICY "Users can manage own smtp_senders" ON private.smtp_senders USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id)';
-EXCEPTION WHEN insufficient_privilege THEN NULL;
+EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL;
 END $$;

--- a/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
+++ b/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
@@ -40,7 +40,7 @@ DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_status ON private.whatsapp_sessio
 DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_active ON private.whatsapp_sessions(is_active); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
 
 -- Enable RLS
-ALTER TABLE private.whatsapp_sessions ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN EXECUTE 'ALTER TABLE private.whatsapp_sessions ENABLE ROW LEVEL SECURITY'; EXCEPTION WHEN insufficient_privilege THEN NULL; END $$;
 
 -- RLS Policies for whatsapp_sessions
 DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can view own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can view own whatsapp sessions" ON private.whatsapp_sessions FOR SELECT USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
Continues unblocking the leadminer.io QA migration deploy. PR #2838 fixed CREATE INDEX and CREATE POLICY on pre-applied tables, but `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` also requires ownership. The next deploy run (`#27032734172`) failed at line 30 of `20260530120000`.

## Changes

- `supabase/migrations/20260530120000_add_smtp_senders.sql`: wrap `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` in a DO block catching `insufficient_privilege`.
- `supabase/migrations/20260601000000_add_whatsapp_gateway.sql`: same pattern for `whatsapp_sessions`.

## Trade-off

Same as PR #2838: when the runner isn't the owner, RLS may be left disabled on QA. Acceptable because whoever pre-applied the table should have enabled it. On a fresh env the migration applies correctly.