### PR TITLE
fix(supabase): revert owner-mismatch DO blocks

### DIFF
--- a/supabase/migrations/20260530120000_add_smtp_senders.sql
+++ b/supabase/migrations/20260530120000_add_smtp_senders.sql
@@ -18,26 +18,12 @@ CREATE TABLE IF NOT EXISTS private.smtp_senders (
    UNIQUE(user_id, email)
  );
 
--- CREATE INDEX / CREATE POLICY / ENABLE RLS on an existing table require
--- ownership. On QA the table may have been pre-applied by a role that
--- doesn't match the migration runner, so these no-op cleanly when we lack
--- privilege. Whoever pre-applied the table is responsible for the
--- index / RLS / policy.
-DO $$
-BEGIN
-  CREATE INDEX idx_smtp_senders_user_id ON private.smtp_senders(user_id);
-EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL;
-END $$;
+CREATE INDEX IF NOT EXISTS idx_smtp_senders_user_id ON private.smtp_senders(user_id);
 
-DO $$
-BEGIN
-  EXECUTE 'ALTER TABLE private.smtp_senders ENABLE ROW LEVEL SECURITY';
-EXCEPTION WHEN insufficient_privilege THEN NULL;
-END $$;
+ALTER TABLE private.smtp_senders ENABLE ROW LEVEL SECURITY;
 
-DO $$
-BEGIN
-  EXECUTE 'DROP POLICY IF EXISTS "Users can manage own smtp_senders" ON private.smtp_senders';
-  EXECUTE 'CREATE POLICY "Users can manage own smtp_senders" ON private.smtp_senders USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id)';
-EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL;
-END $$;
+DROP POLICY IF EXISTS "Users can manage own smtp_senders" ON private.smtp_senders;
+CREATE POLICY "Users can manage own smtp_senders"
+  ON private.smtp_senders
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
+++ b/supabase/migrations/20260601000000_add_whatsapp_gateway.sql
@@ -32,21 +32,33 @@ CREATE TABLE IF NOT EXISTS private.whatsapp_sessions (
 );
 
 -- Indexes
--- CREATE INDEX / CREATE POLICY on an existing table require ownership.
--- On QA the table may have been pre-applied by a role that doesn't match
--- the migration runner, so these no-op cleanly when we lack privilege.
-DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_user_id ON private.whatsapp_sessions(user_id); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
-DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_status ON private.whatsapp_sessions(status); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
-DO $$ BEGIN CREATE INDEX idx_whatsapp_sessions_active ON private.whatsapp_sessions(is_active); EXCEPTION WHEN insufficient_privilege OR duplicate_table THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_user_id ON private.whatsapp_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_status ON private.whatsapp_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_whatsapp_sessions_active ON private.whatsapp_sessions(is_active);
 
 -- Enable RLS
-DO $$ BEGIN EXECUTE 'ALTER TABLE private.whatsapp_sessions ENABLE ROW LEVEL SECURITY'; EXCEPTION WHEN insufficient_privilege THEN NULL; END $$;
+ALTER TABLE private.whatsapp_sessions ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for whatsapp_sessions
-DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can view own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can view own whatsapp sessions" ON private.whatsapp_sessions FOR SELECT USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
-DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can insert own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can insert own whatsapp sessions" ON private.whatsapp_sessions FOR INSERT WITH CHECK (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
-DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can update own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can update own whatsapp sessions" ON private.whatsapp_sessions FOR UPDATE USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
-DO $$ BEGIN EXECUTE 'DROP POLICY IF EXISTS "Users can delete own whatsapp sessions" ON private.whatsapp_sessions'; EXECUTE 'CREATE POLICY "Users can delete own whatsapp sessions" ON private.whatsapp_sessions FOR DELETE USING (auth.uid() = user_id)'; EXCEPTION WHEN insufficient_privilege OR duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS "Users can view own whatsapp sessions" ON private.whatsapp_sessions;
+CREATE POLICY "Users can view own whatsapp sessions"
+  ON private.whatsapp_sessions FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own whatsapp sessions" ON private.whatsapp_sessions;
+CREATE POLICY "Users can insert own whatsapp sessions"
+  ON private.whatsapp_sessions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update own whatsapp sessions" ON private.whatsapp_sessions;
+CREATE POLICY "Users can update own whatsapp sessions"
+  ON private.whatsapp_sessions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own whatsapp sessions" ON private.whatsapp_sessions;
+CREATE POLICY "Users can delete own whatsapp sessions"
+  ON private.whatsapp_sessions FOR DELETE
+  USING (auth.uid() = user_id);
 
 -- Trigger to automatically update updated_at
 CREATE OR REPLACE FUNCTION private.update_whatsapp_session_updated_at()


### PR DESCRIPTION
Reverts the `EXCEPTION WHEN insufficient_privilege` DO blocks added in #2838 and #2839. The deploy now fails loudly when table ownership is misaligned, instead of passing CI while application code hits `permission denied` at runtime.

## Changes

- `supabase/migrations/20260530120000_add_smtp_senders.sql`: restore `CREATE INDEX IF NOT EXISTS` and `DROP POLICY IF EXISTS` + `CREATE POLICY` (from #2836), remove DO blocks.
- `supabase/migrations/20260601000000_add_whatsapp_gateway.sql`: same pattern for the 3 indexes and 4 policies on `whatsapp_sessions`.

## Why revert

The original problem: `private.smtp_senders` and `private.whatsapp_sessions` were created via the Supabase dashboard by a role that doesn't own them from the migration runner's perspective. #2838 and #2839 wrapped the dependent DDL in DO blocks catching `insufficient_privilege` so the migration would no-op silently. That makes CI pass but breaks the real application — every query from the backend or an edge function to these tables would hit `permission denied`.

A failing deploy is the correct signal. The right fix is to align ownership out-of-band: either drop the pre-applied tables so the migration recreates them, or `ALTER TABLE ... OWNER TO <migration_runner_role>`.

## Testing

Verified locally against `supabase_db_leadminer` (PG 15.8). Dropped dependent objects and re-ran both migrations twice; both apply cleanly and are idempotent on second run.