### PR TITLE
fix: account deletion error due to missing $user definition

### DIFF
--- a/frontend/src/pages/account/settings.vue
+++ b/frontend/src/pages/account/settings.vue
@@ -151,6 +151,7 @@
 <script setup lang="ts">
 import type { UserAttributes } from '@supabase/supabase-js';
 import { AcceptNewsLetter } from '~/utils/extras';
+import type { FetchError } from 'ofetch';
 
 import { isInvalidEmail } from '@/utils/email';
 import {
@@ -340,7 +341,7 @@ async function deleteAccount() {
     });
   } catch (err) {
     const message =
-      (err as any)?.response?._data?.error ||
+      (err as unknown as FetchError)?.response?._data?.error ||
       (err as Error)?.message ||
       'Something went wrong';
     $toast.add({

--- a/frontend/src/pages/account/settings.vue
+++ b/frontend/src/pages/account/settings.vue
@@ -172,6 +172,7 @@ const { t: $t } = useI18n({
 
 const $toast = useToast();
 const { $saasEdgeFunctions } = useNuxtApp();
+const $user = useSupabaseUser();
 const $profile = useSupabaseUserProfile();
 
 const {
@@ -315,6 +316,7 @@ async function updateUserDetailsButton() {
 
 async function deleteAccount() {
   isLoading.value = true;
+  showDeleteModal.value = false;
   try {
     await $saasEdgeFunctions('delete-user', {
       method: 'DELETE',
@@ -336,10 +338,19 @@ async function deleteAccount() {
       detail: t('account_deleted_success'),
       life: 3000,
     });
-    isLoading.value = false;
   } catch (err) {
+    const message =
+      (err as any)?.response?._data?.error ||
+      (err as Error)?.message ||
+      'Something went wrong';
+    $toast.add({
+      severity: 'error',
+      summary: 'Oops!',
+      detail: message,
+      life: 5000,
+    });
+  } finally {
     isLoading.value = false;
-    throw err;
   }
 }
 </script>

--- a/supabase/migrations/20260616000000_comprehensive_delete_user_data.sql
+++ b/supabase/migrations/20260616000000_comprehensive_delete_user_data.sql
@@ -1,0 +1,79 @@
+-- Comprehensive fix: update private.delete_user_data to cover ALL user-owned tables
+--
+-- The 20260605150000 fix added smtp_senders, email/sms campaigns and
+-- whatsapp_sessions, but missed three user-owned tables that leave
+-- orphaned rows behind:
+--
+--   - private.email_status    (existing since Nov 2024, no FK cascade)
+--   - private.signatures      (existing since Nov 2025, ON DELETE CASCADE
+--                              to auth.users — no FK issues, but still
+--                              orphaned data)
+--   - private.notifications   (existing since Jun 2026, no FK at all)
+--
+-- Since none of these tables are referenced by FK from other user-owned
+-- tables, they do not cause delete failures — they just waste space.
+-- This migration brings them into the function for completeness.
+--
+-- Also removes the explicit tags deletion: tags are already handled by
+-- private.delete_contacts (called below), which cleans up tags per person.
+-- The duplicate DELETE was harmless but unnecessary.
+--
+-- Deletion order remains: children before parents, to avoid FK violations.
+
+CREATE OR REPLACE FUNCTION private.delete_user_data(user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  owner_id uuid;
+BEGIN
+  owner_id = delete_user_data.user_id;
+
+  -- All user_id references below are qualified with the table alias
+  -- (e.g. "s.user_id") on purpose. The function parameter is named
+  -- "user_id", and in plpgsql an unqualified identifier resolves to
+  -- variables/parameters before columns, so writing the bare column
+  -- name would compare the parameter to itself and either error or
+  -- delete the wrong rows. Do not "clean up" the aliases.
+  -- Tables referencing other user-owned tables; delete dependents first.
+  DELETE FROM private.smtp_senders s WHERE s.user_id = owner_id;
+  DELETE FROM private.email_campaign_links l
+    USING private.email_campaign_recipients r
+    WHERE l.recipient_id = r.id AND r.user_id = owner_id;
+  DELETE FROM private.email_campaign_events e
+    USING private.email_campaign_recipients r
+    WHERE e.recipient_id = r.id AND r.user_id = owner_id;
+  DELETE FROM private.email_campaign_recipients r WHERE r.user_id = owner_id;
+  DELETE FROM private.email_campaigns ec WHERE ec.user_id = owner_id;
+  -- sms_campaign_recipients has no user_id column; join via sms_campaigns
+  -- (which has ON DELETE CASCADE down to recipients, link_clicks, and
+  -- recipient_gateways). sms_campaign_unsubscribes does NOT cascade
+  -- through campaign_id (FK is ON DELETE SET NULL), so it must be
+  -- deleted explicitly by user_id.
+  DELETE FROM private.sms_campaign_link_clicks c
+    USING private.sms_campaigns camp
+    WHERE c.campaign_id = camp.id AND camp.user_id = owner_id;
+  DELETE FROM private.sms_campaign_unsubscribes u WHERE u.user_id = owner_id;
+  DELETE FROM private.sms_campaign_recipient_gateways g
+    USING private.sms_campaigns camp
+    WHERE g.campaign_id = camp.id AND camp.user_id = owner_id;
+  DELETE FROM private.sms_campaign_recipients sr
+    USING private.sms_campaigns camp
+    WHERE sr.campaign_id = camp.id AND camp.user_id = owner_id;
+  DELETE FROM private.sms_campaigns sc WHERE sc.user_id = owner_id;
+  DELETE FROM private.sms_fleet_gateways f WHERE f.user_id = owner_id;
+  DELETE FROM private.whatsapp_sessions w WHERE w.user_id = owner_id;
+
+  -- Tables with direct user_id and no FK dependencies
+  DELETE FROM private.email_status es WHERE es.user_id = owner_id;
+  DELETE FROM private.signatures sig WHERE sig.user_id = owner_id;
+  DELETE FROM private.notifications n WHERE n.user_id = owner_id;
+
+  -- Original RPC body (tags removed — handled by delete_contacts below)
+  DELETE FROM private.messages msg WHERE msg.user_id = owner_id;
+  DELETE FROM private.mining_sources ms WHERE ms.user_id = owner_id;
+  DELETE FROM private.engagement eg WHERE eg.user_id = owner_id;
+  PERFORM private.delete_contacts(owner_id, NULL, TRUE);
+END;
+$$;


### PR DESCRIPTION
**Root cause:** `settings.vue` called `$user.value = null` in `signOutManually`'s `resetUser` callback, but `$user` (`useSupabaseUser()`) was never declared in the component. After a successful deletion, a `ReferenceError` was thrown — but `clearPersistedData()` had already destroyed the session, so on refresh the user landed on the auth page.

**Changes:**
- Added `const $user = useSupabaseUser()` to the component
- Fixed `deleteAccount()` error handling to show the actual error message locally instead of re-throwing to the generic global handler
- Added migration covering `email_status`, `signatures`, and `notifications` to `delete_user_data` RPC (the 3 tables missed by previous patches)
- Removed redundant tags deletion from `delete_user_data` (handled by `delete_contacts`)

Depends on `origin/fix/delete-user-fk-violation` (table alias fixes and corrected SMS joins in 20260605150000 migration).

Resolves #2845