### PR TITLE
feat: unified email senders with SMTP support

### DIFF
--- a/frontend/src/components/mining/PassiveMiningDialog.vue
+++ b/frontend/src/components/mining/PassiveMiningDialog.vue
@@ -34,6 +34,7 @@ const miningSource = ref<MiningSource>();
 
 const $leadminerStore = useLeadminerStore();
 const $supabase = useSupabaseClient();
+const $toast = useToast();
 
 const { t } = useI18n({
   useScope: 'local',
@@ -54,15 +55,25 @@ function closePassiveMiningDialog() {
 
 async function enablePassiveMining() {
   if (miningSource.value) {
-    const { error } = await $supabase
-      // @ts-expect-error: Issue with nuxt/supabase
-      .schema('private')
-      .from('mining_sources')
-      .update({ passive_mining: true })
-      .match({ email: miningSource.value.email });
+    try {
+      const { error } = await $supabase
+        // @ts-expect-error: Issue with nuxt/supabase
+        .schema('private')
+        .from('mining_sources')
+        .update({ passive_mining: true })
+        .match({ email: miningSource.value.email });
 
-    if (error) {
-      throw error;
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      $toast.add({
+        severity: 'error',
+        summary: t('passive_mining_update_failed'),
+        detail: (error as Error).message,
+        life: 4500,
+      });
+      return;
     }
   }
   closePassiveMiningDialog();
@@ -75,14 +86,15 @@ async function enablePassiveMining() {
     "header": "Continuous Contact Extraction",
     "paragraph_1": "New contacts found in incoming emails will be automatically saved.",
     "paragraph_2": "Enable continuous contact extraction from future emails?",
-    "yes_enable": "Yes, enable"
+    "yes_enable": "Yes, enable",
+    "passive_mining_update_failed": "Unable to update continuous mining"
   },
   "fr": {
     "header": "Extraction continue des contacts",
     "paragraph_1": "Les nouveaux contacts trouvés dans les e-mails entrants seront automatiquement enregistrés.",
     "paragraph_2": "Activer l'extraction continue des contacts à partir des futurs e-mails ?",
-
-    "yes_enable": "Oui, activer"
+    "yes_enable": "Oui, activer",
+    "passive_mining_update_failed": "Impossible de mettre à jour l'extraction continue"
   }
 }
 </i18n>

--- a/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
+++ b/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
@@ -47,8 +47,10 @@
       v-if="!$leadminerStore.activeMiningTask"
       id="mine-stepper-start-button"
       :disabled="
+        (sourceType === 'email' && $leadminerStore.isLoadingBoxes) ||
         (sourceType === 'email' &&
-          ($leadminerStore.isLoadingBoxes || totalEmails === 0)) ||
+          totalEmails === 0 &&
+          !$leadminerStore.googleContactsSyncEnabled) ||
         $leadminerStore.isLoadingStartMining
       "
       :loading="$leadminerStore.isLoadingStartMining"
@@ -397,11 +399,12 @@ function openMiningSettings() {
 }
 
 async function startMiningBoxes() {
-  if (
+  const hasCheckedBoxes =
     Object.keys(selectedBoxes.value).filter(
       (key) => selectedBoxes.value[key].checked && key !== '',
-    ).length === 0
-  ) {
+    ).length > 0;
+
+  if (!hasCheckedBoxes && !$leadminerStore.googleContactsSyncEnabled) {
     openMiningSettings();
     $toast.add({
       severity: 'error',

--- a/frontend/src/components/senders/EmailSenderManagement.vue
+++ b/frontend/src/components/senders/EmailSenderManagement.vue
@@ -7,6 +7,10 @@ import { useSmtpSendersStore } from '~/stores/smtp-senders';
 import AddEmailSenderDialog from './AddEmailSenderDialog.vue';
 import type { SmtpSender } from '@/types/smtp-senders';
 
+defineProps<{
+  hideAddButton?: boolean;
+}>();
+
 const { t } = useI18n({ useScope: 'local' });
 const { t: globalT } = useI18n({ useScope: 'global' });
 const $confirm = useConfirm();
@@ -21,6 +25,8 @@ function openAddDialog() {
   editingSender.value = null;
   showAddDialog.value = true;
 }
+
+defineExpose({ openAddDialog });
 
 function openEditDialog(sender: SmtpSender) {
   editingSender.value = sender;
@@ -86,7 +92,7 @@ onMounted(() => {
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-center justify-end">
+    <div v-if="!hideAddButton" class="flex items-center justify-end">
       <Button
         :label="t('add_email_sender')"
         icon="pi pi-plus"

--- a/frontend/src/components/sms-fleet/SmsFleetManagement.vue
+++ b/frontend/src/components/sms-fleet/SmsFleetManagement.vue
@@ -20,6 +20,7 @@ type SupportedProvider = 'smsgate' | 'simple-sms-gateway';
 
 const props = defineProps<{
   autoAdd?: boolean;
+  hideAddButton?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -212,11 +213,13 @@ function getProviderLabel(provider: SmsGatewayProvider): string {
 onMounted(() => {
   $smsFleetStore.fetchGateways();
 });
+
+defineExpose({ openAddDialog });
 </script>
 
 <template>
   <div class="flex flex-col gap-4">
-    <div class="flex items-center justify-end">
+    <div v-if="!hideAddButton" class="flex items-center justify-end">
       <Button
         :label="t('add_gateway')"
         icon="pi pi-plus"

--- a/frontend/src/pages/campaigns.vue
+++ b/frontend/src/pages/campaigns.vue
@@ -2,16 +2,34 @@
   <div class="flex flex-col gap-4">
     <Panel toggleable class="border border-surface-200 rounded-md p-4">
       <template #header>
-        <div class="flex items-center gap-4 w-full">
-          <h1 class="text-xl font-semibold">{{ t('senders') }}</h1>
-          <SenderFilterTabs v-model="senderFilter" />
+        <div class="flex items-center justify-between gap-4 w-full">
+          <div class="flex items-center gap-4">
+            <h1 class="text-xl font-semibold">{{ t('senders') }}</h1>
+            <SenderFilterTabs v-model="senderFilter" />
+          </div>
+          <div class="flex items-center gap-2">
+            <Button
+              v-if="senderFilter !== 'sms'"
+              :label="t('add_email_sender')"
+              icon="pi pi-plus"
+              outlined
+              @click.stop="emailSenderManagementRef?.openAddDialog()"
+            />
+            <Button
+              v-if="senderFilter !== 'email'"
+              :label="t('add_sms_gateway')"
+              icon="pi pi-plus"
+              outlined
+              @click.stop="smsFleetManagementRef?.openAddDialog()"
+            />
+          </div>
         </div>
       </template>
       <div v-show="senderFilter !== 'sms'">
-        <EmailSenderManagement />
+        <EmailSenderManagement ref="emailSenderManagementRef" hide-add-button />
       </div>
       <div v-show="senderFilter !== 'email'">
-        <SmsFleetManagement />
+        <SmsFleetManagement ref="smsFleetManagementRef" hide-add-button />
       </div>
     </Panel>
 
@@ -395,6 +413,12 @@ import type { SenderFilter } from '~/components/senders/SenderFilterTabs.vue';
 const $campaignsStore = useCampaignsStore();
 const senderFilter = ref<SenderFilter>('all');
 const campaignFilter = ref<SenderFilter>('all');
+const emailSenderManagementRef = ref<InstanceType<
+  typeof EmailSenderManagement
+> | null>(null);
+const smsFleetManagementRef = ref<InstanceType<
+  typeof SmsFleetManagement
+> | null>(null);
 
 const filteredCampaigns = computed(() => {
   if (campaignFilter.value === 'all') return $campaignsStore.campaigns;
@@ -767,6 +791,8 @@ onBeforeUnmount(() => {
   "en": {
     "sms_gateways": "SMS Gateways",
     "senders": "Senders",
+    "add_email_sender": "Add Email Sender",
+    "add_sms_gateway": "Add SMS Gateway",
     "campaigns": "Campaigns",
     "refresh": "Refresh",
     "no_campaigns": "No campaigns yet",
@@ -828,6 +854,8 @@ onBeforeUnmount(() => {
   "fr": {
     "sms_gateways": "Passerelles SMS",
     "senders": "Expéditeurs",
+    "add_email_sender": "Ajouter un expéditeur email",
+    "add_sms_gateway": "Ajouter une passerelle SMS",
     "campaigns": "Campagnes",
     "refresh": "Rafraîchir",
     "no_campaigns": "Aucune campagne",

--- a/supabase/functions/email-campaigns/middlewares-mod.ts
+++ b/supabase/functions/email-campaigns/middlewares-mod.ts
@@ -286,8 +286,6 @@ export async function complianceMiddleware(c: Context, next: Next) {
       userId: user.id,
       payload,
     });
-
-    return await next();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Campaign check failed", {
@@ -303,4 +301,10 @@ export async function complianceMiddleware(c: Context, next: Next) {
       500,
     );
   }
+
+  // Call next() OUTSIDE the compliance try-catch so downstream errors (e.g.
+  // billing service unavailability) propagate to the framework's error
+  // handler instead of being masked as compliance CHECK_FAILED failures.
+  // Billing is best-effort and must not block campaign creation.
+  return await next();
 }

--- a/supabase/functions/email-campaigns/tests/campaign-bill-middleware.test.ts
+++ b/supabase/functions/email-campaigns/tests/campaign-bill-middleware.test.ts
@@ -3,8 +3,8 @@ import { Context } from "hono";
 Deno.test({
   name: "campaign-bill-middleware: should skip non-create paths",
   async fn() {
-    const { campaignBillMiddleware } =
-      await import("../campaign-bill-middleware.ts");
+    const { createFinalResponseMiddleware } =
+      await import("../middlewares-mod.ts");
 
     let nextCalled = false;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -15,7 +15,7 @@ Deno.test({
       json: () => {},
     } as unknown as Context;
 
-    await campaignBillMiddleware(context, async () => {
+    await createFinalResponseMiddleware(context, async () => {
       nextCalled = true;
     });
 
@@ -28,8 +28,8 @@ Deno.test({
 Deno.test({
   name: "campaign-bill-middleware: should return 500 when campaign data missing",
   async fn() {
-    const { campaignBillMiddleware } =
-      await import("../campaign-bill-middleware.ts");
+    const { createFinalResponseMiddleware } =
+      await import("../middlewares-mod.ts");
 
     let jsonResult: Record<string, unknown> | undefined;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -49,7 +49,7 @@ Deno.test({
     };
 
     try {
-      await campaignBillMiddleware(context, async () => {});
+      await createFinalResponseMiddleware(context, async () => {});
     } finally {
       Deno.env.get = originalEnv;
     }
@@ -71,8 +71,8 @@ Deno.test({
 Deno.test({
   name: "campaign-bill-middleware: should return success when billing disabled",
   async fn() {
-    const { campaignBillMiddleware } =
-      await import("../campaign-bill-middleware.ts");
+    const { createFinalResponseMiddleware } =
+      await import("../middlewares-mod.ts");
 
     let jsonResult: Record<string, unknown> | undefined;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -101,7 +101,7 @@ Deno.test({
     };
 
     try {
-      await campaignBillMiddleware(context, async () => {});
+      await createFinalResponseMiddleware(context, async () => {});
     } finally {
       Deno.env.get = originalEnv;
     }
@@ -133,8 +133,8 @@ Deno.test({
 Deno.test({
   name: "campaign-bill-middleware: should return success when charge fails (campaign exists)",
   async fn() {
-    const { campaignBillMiddleware } =
-      await import("../campaign-bill-middleware.ts");
+    const { createFinalResponseMiddleware } =
+      await import("../middlewares-mod.ts");
 
     let jsonResult: Record<string, unknown> | undefined;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -163,7 +163,7 @@ Deno.test({
     };
 
     try {
-      await campaignBillMiddleware(context, async () => {});
+      await createFinalResponseMiddleware(context, async () => {});
     } finally {
       Deno.env.get = originalEnv;
     }

--- a/supabase/functions/email-campaigns/tests/campaign-check-middleware.test.ts
+++ b/supabase/functions/email-campaigns/tests/campaign-check-middleware.test.ts
@@ -1,10 +1,16 @@
 import { Context } from "hono";
 
+// Set env vars before middlewares-mod.ts is dynamically imported.
+// createSupabaseAdmin reads SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY at
+// module load time; without these, createClient throws "supabaseUrl is required".
+Deno.env.set("SUPABASE_URL", "http://localhost:54321");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key");
+
 Deno.test({
   name: "campaign-check-middleware: should skip non-create paths",
   async fn() {
-    const { campaignCheckMiddleware } =
-      await import("../campaign-check-middleware.ts");
+    const { complianceMiddleware } = await import("../middlewares-mod.ts");
 
     let nextCalled = false;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -15,7 +21,7 @@ Deno.test({
       json: () => {},
     } as unknown as Context;
 
-    await campaignCheckMiddleware(context, async () => {
+    await complianceMiddleware(context, async () => {
       nextCalled = true;
     });
 
@@ -28,8 +34,7 @@ Deno.test({
 Deno.test({
   name: "campaign-check-middleware: should return 400 when no contacts selected",
   async fn() {
-    const { campaignCheckMiddleware } =
-      await import("../campaign-check-middleware.ts");
+    const { complianceMiddleware } = await import("../middlewares-mod.ts");
 
     let jsonResult: Record<string, unknown> | undefined;
     // skipcq: JS-0323 - Test mock requires minimal Context interface
@@ -48,7 +53,7 @@ Deno.test({
       },
     } as unknown as Context;
 
-    await campaignCheckMiddleware(context, async () => {});
+    await complianceMiddleware(context, async () => {});
 
     if (
       !jsonResult ||
@@ -138,6 +143,100 @@ Deno.test({
     }
     if (reason !== "credits") {
       throw new Error(`Expected reason 'credits', got: ${reason}`);
+    }
+  },
+});
+
+Deno.test({
+  name: "complianceMiddleware: should NOT mask downstream billing errors as CHECK_FAILED (regression)",
+  async fn() {
+    const { complianceMiddleware } = await import("../middlewares-mod.ts");
+
+    // Stub globalThis.fetch so createSupabaseAdmin's client returns canned
+    // consenting contacts without hitting a real database. PostgREST returns
+    // the row array directly as the response body for .select() queries;
+    // supabase-js then exposes it as { data: <body>, error: null }.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              email: "consented@example.com",
+              consent_status: "legitimate_interest",
+              updated_at: "2024-01-01T00:00:00Z",
+            },
+          ]),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+    }) as typeof globalThis.fetch;
+
+    let jsonResult: Record<string, unknown> | undefined;
+    const context = {
+      req: {
+        path: "/campaigns/create",
+        json: async () => ({
+          selectedEmails: ["consented@example.com"],
+          partial_one: true,
+        }),
+      },
+      get: (key: string) => {
+        if (key === "user") {
+          return { id: "user-123", user_metadata: {} };
+        }
+        return undefined;
+      },
+      set: () => {},
+      json: (data: unknown, status?: number) => {
+        jsonResult = { data: data as Record<string, unknown>, status };
+      },
+    } as unknown as Context;
+
+    // next() simulates the commercial billing middleware throwing when the
+    // billing Edge Function returns a non-2xx status code. This is the exact
+    // error from the bug report.
+    const billingError = new Error(
+      "Billing service unavailable: Edge Function returned a non-2xx status code",
+    );
+    const next = async () => {
+      throw billingError;
+    };
+
+    let caughtError: unknown = undefined;
+    try {
+      await complianceMiddleware(context, next);
+    } catch (error) {
+      caughtError = error;
+    }
+
+    globalThis.fetch = originalFetch;
+
+    // The billing error MUST propagate, NOT be masked as a compliance
+    // CHECK_FAILED response. If jsonResult is set with code CHECK_FAILED,
+    // the bug is present (the catch block swallowed the downstream error).
+    if (jsonResult) {
+      const code = (jsonResult.data as Record<string, unknown>)?.code;
+      if (code === "CHECK_FAILED") {
+        throw new Error(
+          `BUG: complianceMiddleware masked downstream billing error as CHECK_FAILED. ` +
+            `Billing should be best-effort and must not block campaign creation. ` +
+            `Got: ${JSON.stringify(jsonResult)}`,
+        );
+      }
+    }
+
+    // The error should propagate to the caller (Hono/commercial error handler).
+    if (caughtError !== billingError) {
+      throw new Error(
+        `Expected billing error to propagate, but it was swallowed. ` +
+          `caughtError: ${String(caughtError)}, jsonResult: ${JSON.stringify(
+            jsonResult,
+          )}`,
+      );
     }
   },
 });

--- a/supabase/migrations/20260530120000_add_smtp_senders.sql
+++ b/supabase/migrations/20260530120000_add_smtp_senders.sql
@@ -26,3 +26,41 @@ CREATE POLICY "Users can manage own smtp_senders"
   ON private.smtp_senders
   USING (auth.uid() = user_id)
   WITH CHECK (auth.uid() = user_id);
+
+-- Backfill smtp_senders for existing OAuth mining sources (Google / Azure).
+-- The oauth_refresh_token is left NULL; the backend resolves the token from
+-- the linked mining_sources row (via mining_source_email) at send time.
+INSERT INTO private.smtp_senders (
+  user_id,
+  name,
+  email,
+  smtp_host,
+  smtp_port,
+  smtp_encryption,
+  smtp_user,
+  auth_type,
+  oauth_provider,
+  active,
+  mining_source_email
+)
+SELECT
+  ms.user_id,
+  CASE
+    WHEN ms.type = 'google' THEN 'Gmail (' || ms.email || ')'
+    WHEN ms.type = 'azure'  THEN 'Outlook (' || ms.email || ')'
+  END,
+  ms.email,
+  CASE
+    WHEN ms.type = 'google' THEN 'smtp.gmail.com'
+    WHEN ms.type = 'azure'  THEN 'smtp-mail.outlook.com'
+  END,
+  587,
+  'starttls',
+  ms.email,
+  'oauth',
+  ms.type,
+  TRUE,
+  ms.email
+FROM private.mining_sources ms
+WHERE ms.type IN ('google', 'azure')
+ON CONFLICT (user_id, email) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds SMTP sender management to the leadminer platform, enabling users to configure custom SMTP servers for sending emails alongside the existing OAuth-based sending.

### Changes

**Backend:**
- New SMTP senders controller with full CRUD, test connection, and autodetect
- `PgSmtpSenders` data access layer for the `smtp_senders` table
- Routes wired into the app (`/api/smtp-senders`)
- Validation schemas for SMTP sender operations

**Frontend:**
- `EmailSenderManagement` component for managing email senders (IMAP + SMTP)
- `AddEmailSenderDialog` for adding new SMTP senders
- `smtp-senders` Pinia store
- `smtp-senders.ts` TypeScript types
- Updated campaigns page with aligned sender buttons (email + SMS)
- Auto-regenerate SMTP senders from existing IMAP sources

**Database:**
- Migration: `20260530120000_add_smtp_senders.sql` — creates the `smtp_senders` table

**Auto-sync:**
- When an OAuth mining source is created, an SMTP sender is automatically backfilled from existing credentials

---

Closes #<issue_number> (if applicable)