### PR TITLE
fix(frontend): reconnect to edge fn, table defaults, SMS gateway icon

### DIFF
--- a/frontend/src/components/campaigns/CampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/CampaignComposerDialog.vue
@@ -366,6 +366,7 @@ import {
   getUnavailableSenderReconnectContext,
 } from '@/utils/senderOptions';
 import { updateMiningSourcesValidityFromUnavailable } from '@/utils/sources';
+import { addOAuthAccount } from '@/utils/oauth';
 import Editor from 'primevue/editor';
 import GenericComplianceDialog, {
   type ModalData,
@@ -379,7 +380,7 @@ const props = defineProps<{
 
 const { t } = useI18n({ useScope: 'local' });
 const { t: globalT } = useI18n({ useScope: 'global' });
-const { $api, $saasEdgeFunctions } = useNuxtApp();
+const { $saasEdgeFunctions } = useNuxtApp();
 const $screenStore = useScreenStore();
 const $leadminer = useLeadminerStore();
 const $imapDialogStore = useImapDialog();
@@ -914,22 +915,7 @@ async function reconnectSenderSource(email: string) {
   }
 
   try {
-    await useSupabaseClient().auth.refreshSession();
-    const { authorizationUri } = await $api<{ authorizationUri: string }>(
-      `/imap/mine/sources/${source.type}`,
-      {
-        method: 'POST',
-        body: {
-          redirect: '/sources',
-        },
-      },
-    );
-
-    if (!authorizationUri) {
-      throw new Error(t('reconnect_unavailable'));
-    }
-
-    await navigateTo(authorizationUri, { external: true });
+    await addOAuthAccount(source.type, '/sources');
   } catch (error) {
     $toast.add({
       severity: 'error',

--- a/frontend/src/components/mining/table/MiningTable.vue
+++ b/frontend/src/components/mining/table/MiningTable.vue
@@ -264,7 +264,6 @@
                   <MultiSelect
                     v-model="$contactsStore.visibleColumns"
                     :options="visibleColumnsOptions"
-                    :option-disabled="disabledColumns"
                     option-label="label"
                     class="min-w-56"
                     fluid
@@ -273,7 +272,6 @@
                       t('visible_columns', $contactsStore.visibleColumns.length)
                     "
                     :max-selected-labels="0"
-                    @change="onSelectColumnsChange"
                   />
                 </li>
               </ul>
@@ -1376,18 +1374,8 @@ const visibleColumnsOptions = computed(() => [
   { label: t('mining_id'), value: 'mining_id' },
 ]);
 
-function disabledColumns(column: { label: string; value: string }) {
-  return column.value === 'contacts';
-}
-function onSelectColumnsChange() {
-  // PrimeVue bug fix: MultiSelect: Can deselect disabled options https://github.com/primefaces/primevue/issues/5490
-  if (!visibleColumns.value.includes('contacts')) {
-    visibleColumns.value.push('contacts');
-  }
-}
-
 function getDefaultVisibleColumns() {
-  return ['contacts', 'location', 'works_for', 'job_title', 'actions'];
+  return ['contacts', 'name', 'location', 'works_for', 'job_title'];
 }
 
 /* Table dynamic Height */

--- a/frontend/src/components/sms-fleet/SmsFleetManagement.vue
+++ b/frontend/src/components/sms-fleet/SmsFleetManagement.vue
@@ -219,6 +219,16 @@ function getProviderLabel(provider: SmsGatewayProvider): string {
   return labels[provider] || provider;
 }
 
+function getProviderIcon(provider: SmsGatewayProvider): string {
+  const icons: Record<SmsGatewayProvider, string> = {
+    smsgate: 'pi pi-android',
+    'simple-sms-gateway': 'pi pi-mobile',
+    'sms-gateway': 'pi pi-mobile',
+    twilio: 'pi pi-phone',
+  };
+  return icons[provider] || 'pi pi-mobile';
+}
+
 defineExpose({ openAddDialog });
 
 onMounted(() => {
@@ -249,6 +259,11 @@ onMounted(() => {
         class="flex items-center justify-between p-4 border border-surface-200 rounded-md"
       >
         <div class="flex items-center gap-3">
+          <i
+            :class="getProviderIcon(gateway.provider)"
+            class="text-surface-500 text-lg"
+            :aria-label="getProviderLabel(gateway.provider)"
+          />
           <div class="flex flex-col">
             <span class="font-medium">{{ gateway.name }}</span>
             <span class="text-sm text-surface-500">

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -299,7 +299,7 @@ const $leadminer = useLeadminerStore();
 const { t } = useI18n({
   useScope: 'local',
 });
-const { $api, $saasEdgeFunctions } = useNuxtApp();
+const { $saasEdgeFunctions } = useNuxtApp();
 const $toast = useToast();
 const $route = useRoute();
 const $router = useRouter();
@@ -526,22 +526,7 @@ async function reconnectExpiredSource(source: MiningSource) {
       throw new Error(t('reconnect_unavailable'));
     }
 
-    await useSupabaseClient().auth.refreshSession();
-    const { authorizationUri } = await $api<{ authorizationUri: string }>(
-      `/imap/mine/sources/${source.type}`,
-      {
-        method: 'POST',
-        body: {
-          redirect: '/sources',
-        },
-      },
-    );
-
-    if (!authorizationUri) {
-      throw new Error(t('reconnect_unavailable'));
-    }
-
-    await navigateTo(authorizationUri, { external: true });
+    await addOAuthAccount(source.type, '/sources');
   } catch (error) {
     $toast.add({
       severity: 'error',

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -281,6 +281,10 @@ export const useContactsStore = defineStore('contacts-store', () => {
     return [...columns];
   }
 
+  function ensureNameColumn(columns: string[]): string[] {
+    return columns.includes('name') ? columns : [...columns, 'name'];
+  }
+
   function initializeVisibleColumns(
     defaultColumns: string[],
     origin: TableOrigin,
@@ -288,7 +292,9 @@ export const useContactsStore = defineStore('contacts-store', () => {
   ) {
     const userId = getCurrentUserId();
     if (!userId || !import.meta.client) {
-      visibleColumns.value = sanitizeVisibleColumns(defaultColumns);
+      visibleColumns.value = ensureNameColumn(
+        sanitizeVisibleColumns(defaultColumns),
+      );
       return;
     }
 
@@ -298,19 +304,25 @@ export const useContactsStore = defineStore('contacts-store', () => {
 
     if (!storedColumns) {
       if (contacts && contacts.length > 0) {
-        visibleColumns.value = sanitizeVisibleColumns(
-          getAutoVisibleColumns(contacts),
+        visibleColumns.value = ensureNameColumn(
+          sanitizeVisibleColumns(getAutoVisibleColumns(contacts)),
         );
       } else {
-        visibleColumns.value = sanitizeVisibleColumns(defaultColumns);
+        visibleColumns.value = ensureNameColumn(
+          sanitizeVisibleColumns(defaultColumns),
+        );
       }
       return;
     }
 
     try {
-      visibleColumns.value = sanitizeVisibleColumns(JSON.parse(storedColumns));
+      visibleColumns.value = ensureNameColumn(
+        sanitizeVisibleColumns(JSON.parse(storedColumns)),
+      );
     } catch {
-      visibleColumns.value = sanitizeVisibleColumns(defaultColumns);
+      visibleColumns.value = ensureNameColumn(
+        sanitizeVisibleColumns(defaultColumns),
+      );
     }
   }
 

--- a/frontend/src/tests/unit/table-preferences.test.ts
+++ b/frontend/src/tests/unit/table-preferences.test.ts
@@ -16,15 +16,23 @@ describe('table preferences helpers', () => {
     );
   });
 
-  it('sanitizes visible columns and keeps contacts mandatory', () => {
-    const sanitized = sanitizeVisibleColumns([
+  it('sanitizes visible columns without forcing any column', () => {
+    const withContacts = sanitizeVisibleColumns([
       'temperature',
       'unknown_column',
       'contacts',
       'temperature',
     ]);
 
-    expect(sanitized).toEqual(['temperature', 'contacts']);
+    expect(withContacts).toEqual(['temperature', 'contacts']);
+
+    const withoutContacts = sanitizeVisibleColumns([
+      'temperature',
+      'name',
+      'contacts',
+    ]).filter((column) => column !== 'contacts');
+
+    expect(withoutContacts).toEqual(['temperature', 'name']);
   });
 
   it('restores Date values in date filters from JSON', () => {

--- a/frontend/src/utils/table-preferences.ts
+++ b/frontend/src/utils/table-preferences.ts
@@ -54,7 +54,7 @@ export function buildTableStorageKey(
 
 export function sanitizeVisibleColumns(columns: unknown): string[] {
   if (!Array.isArray(columns)) {
-    return ['contacts'];
+    return [];
   }
 
   const sanitized = columns.filter(
@@ -62,12 +62,7 @@ export function sanitizeVisibleColumns(columns: unknown): string[] {
       typeof column === 'string' && ALLOWED_COLUMNS.has(column),
   );
 
-  const unique = [...new Set(sanitized)];
-  if (!unique.includes('contacts')) {
-    unique.push('contacts');
-  }
-
-  return unique;
+  return [...new Set(sanitized)];
 }
 
 function reviveDateFilters(filters: ParsedFilters) {


### PR DESCRIPTION
- resloves #2861

Route both OAuth reconnect flows (sources page + campaign composer toast) through the `mining-sources/oauth/authorize` edge function via `addOAuthAccount()`. The old backend `/imap/mine/sources/<provider>` route 404'd for google/azure.

- **Reconnect:** `pages/sources.vue` + `CampaignComposerDialog.vue` use the edge function util; removed the now-unused `$api` destructure. The `/imap/mine/*` mining, boxes, and SSE progress calls stay on backend per scope.
- **Table defaults:** `MiningTable.vue` adds `name` to default visible columns and drops the invalid `actions` key. `contacts` (emails) is now toggleable. `table-preferences.ts` no longer force-adds `contacts`; unit test updated.
- **Name migration:** `stores/contacts.ts` adds an idempotent `ensureNameColumn()` wrap so existing users pick up the `name` column on next load without losing their other choices.
- **SMS gateway icon:** `SmsFleetManagement.vue` renders a per-provider icon in each row (smsgate→android, simple-sms-gateway→mobile, sms-gateway→mobile, twilio→phone) mirroring `FleetGatewaySelector.vue`.

How tested: eslint 0 errors on the 7 changed files, vitest 4/4 pass on `tests/unit/table-preferences.test.ts`, prettier --write clean.