### PR TITLE
feat: allow mining with Google Contacts only (no IMAP boxes required)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/plans/
 .agents/
 skills-lock.json
 supabase/snippets/*
+.slim/deepwork/

--- a/backend/src/services/tasks-manager-v2/factories.ts
+++ b/backend/src/services/tasks-manager-v2/factories.ts
@@ -41,24 +41,29 @@ export function createImapMining(
 
   const tasks: Task[] = [];
 
-  tasks.push(
-    new FetchTask({
-      miningId,
-      userId: params.userId,
-      outputStream: streams.messagesStream,
-      fetcherClient: params.fetcherClient,
-      extractSignatures: params.fetchEmailBody,
-      signatureStream: streams.signatureStream,
-      fetchParams: {
-        email: params.email,
-        folders: params.boxes,
-        since: params.since
-      },
-      passive_mining: params.passiveMining
-    })
-  );
+  const hasBoxes = params.boxes.length > 0;
+  const hasGoogleContacts = params.googleContactsSync;
 
-  if (params.googleContactsSync) {
+  if (hasBoxes) {
+    tasks.push(
+      new FetchTask({
+        miningId,
+        userId: params.userId,
+        outputStream: streams.messagesStream,
+        fetcherClient: params.fetcherClient,
+        extractSignatures: params.fetchEmailBody,
+        signatureStream: streams.signatureStream,
+        fetchParams: {
+          email: params.email,
+          folders: params.boxes,
+          since: params.since
+        },
+        passive_mining: params.passiveMining
+      })
+    );
+  }
+
+  if (hasGoogleContacts) {
     tasks.push(
       new GoogleContactsFetchTask({
         miningId,
@@ -114,7 +119,7 @@ export function createImapMining(
     );
   }
 
-  if (params.fetchEmailBody) {
+  if (params.fetchEmailBody && hasBoxes) {
     tasks.push(
       new SignatureTask({
         miningId,
@@ -139,11 +144,17 @@ export function createImapMining(
     deps
   );
 
-  const upstreams: string[] = [TaskId.Fetch];
-  if (params.googleContactsSync) {
+  const upstreams: string[] = [];
+  if (hasBoxes) {
+    upstreams.push(TaskId.Fetch);
+  }
+  if (hasGoogleContacts) {
     upstreams.push(TaskId.GoogleContactsFetch);
   }
-  pipeline.addProgressLink(TaskId.Extract, upstreams);
+
+  if (upstreams.length > 0) {
+    pipeline.addProgressLink(TaskId.Extract, upstreams);
+  }
 
   if (params.cleaningEnabled && hasEmailVerificationConfigured(ENV)) {
     pipeline.addProgressLink(TaskId.Clean, TaskId.Extract, {
@@ -151,7 +162,7 @@ export function createImapMining(
     });
   }
 
-  if (params.fetchEmailBody) {
+  if (params.fetchEmailBody && hasBoxes) {
     pipeline.addProgressLink(TaskId.Signature, TaskId.Fetch, {
       skipTotal: true
     });

--- a/backend/src/validators/mining.schema.ts
+++ b/backend/src/validators/mining.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringField, positiveNumber, stringArray } from './index';
+import { stringField, positiveNumber } from './index';
 
 export const createImapMiningSourceSchema = z.object({
   body: z.object({
@@ -15,22 +15,29 @@ export const startMiningSchema = z.object({
   params: z.object({
     userId: stringField
   }),
-  body: z.object({
-    miningSource: z
-      .object({
-        email: stringField.optional(),
-        id: stringField.optional()
-      })
-      .refine((data) => data.email || data.id, {
-        message: 'Either miningSource.email or miningSource.id is required'
-      }),
-    boxes: stringArray,
-    extractSignatures: z.boolean(),
-    cleaningEnabled: z.boolean(),
-    since: z.string().optional(),
-    passive_mining: z.boolean().optional(),
-    googleContactsSync: z.boolean().optional()
-  })
+  body: z
+    .object({
+      miningSource: z
+        .object({
+          email: stringField.optional(),
+          id: stringField.optional()
+        })
+        .refine((data) => data.email || data.id, {
+          message: 'Either miningSource.email or miningSource.id is required'
+        }),
+      boxes: z
+        .array(z.string().min(1, 'must be a non-empty string'))
+        .default([]),
+      extractSignatures: z.boolean(),
+      cleaningEnabled: z.boolean(),
+      since: z.string().optional(),
+      passive_mining: z.boolean().optional(),
+      googleContactsSync: z.boolean().optional()
+    })
+    .refine((data) => data.googleContactsSync || data.boxes.length > 0, {
+      message: 'boxes must be non-empty when Google Contacts sync is disabled',
+      path: ['boxes']
+    })
 });
 
 export const startMiningFileSchema = z.object({

--- a/backend/test/integration/tasks-manager-v2/Pipeline.integration.test.ts
+++ b/backend/test/integration/tasks-manager-v2/Pipeline.integration.test.ts
@@ -12,6 +12,7 @@ import type { FetcherClient } from '../../../src/services/tasks-manager-v2/tasks
 import type { Tasks } from '../../../src/db/interfaces/Tasks';
 import SSEBroadcasterFactory from '../../../src/services/factory/SSEBroadcasterFactory';
 import SupabaseTasks from '../../../src/db/supabase/tasks';
+import { TaskId } from '../../../src/services/tasks-manager-v2/types';
 
 jest.mock('../../../src/config', () => ({
   LEADMINER_API_LOG_LEVEL: 'error',
@@ -241,6 +242,118 @@ describe('Pipeline Integration', () => {
       expect(pipeline.getTask('fetch')).toBeDefined();
       expect(pipeline.getTask('extract')).toBeDefined();
       expect(pipeline.getTask('signature')).toBeDefined();
+    });
+  });
+
+  describe('Google Contacts mining scenario', () => {
+    it('should create pipeline with GoogleContactsFetchTask + ExtractTask (no FetchTask, no SignatureTask) when boxes: [] + googleContactsSync: true', () => {
+      const mockFetcher = {
+        startFetch: jest
+          .fn()
+          .mockResolvedValue({ data: { totalMessages: 100 } } as never),
+        stopFetch: jest.fn<() => Promise<void>>().mockResolvedValue()
+      } as unknown as FetcherClient;
+
+      const pipeline = createImapMining(
+        {
+          miningId: 'test-gc-only',
+          userId: 'user-1',
+          email: 'test@example.com',
+          boxes: [],
+          fetchEmailBody: false,
+          cleaningEnabled: false,
+          fetcherClient: mockFetcher,
+          googleContactsSync: true
+        },
+        pipelineDeps
+      );
+
+      expect(pipeline.getTask(TaskId.GoogleContactsFetch)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Extract)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Fetch)).toBeUndefined();
+      expect(pipeline.getTask(TaskId.Signature)).toBeUndefined();
+    });
+
+    it('should create pipeline with GoogleContactsFetchTask + ExtractTask + CleanTask when boxes: [] + googleContactsSync: true + cleaningEnabled: true', () => {
+      const mockFetcher = {
+        startFetch: jest
+          .fn()
+          .mockResolvedValue({ data: { totalMessages: 100 } } as never),
+        stopFetch: jest.fn<() => Promise<void>>().mockResolvedValue()
+      } as unknown as FetcherClient;
+
+      const pipeline = createImapMining(
+        {
+          miningId: 'test-gc-clean',
+          userId: 'user-1',
+          email: 'test@example.com',
+          boxes: [],
+          fetchEmailBody: false,
+          cleaningEnabled: true,
+          fetcherClient: mockFetcher,
+          googleContactsSync: true
+        },
+        pipelineDeps
+      );
+
+      expect(pipeline.getTask(TaskId.GoogleContactsFetch)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Extract)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Clean)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Fetch)).toBeUndefined();
+    });
+
+    it('should create pipeline with FetchTask + GoogleContactsFetchTask + ExtractTask when boxes: ["INBOX"] + googleContactsSync: true', () => {
+      const mockFetcher = {
+        startFetch: jest
+          .fn()
+          .mockResolvedValue({ data: { totalMessages: 100 } } as never),
+        stopFetch: jest.fn<() => Promise<void>>().mockResolvedValue()
+      } as unknown as FetcherClient;
+
+      const pipeline = createImapMining(
+        {
+          miningId: 'test-combined',
+          userId: 'user-1',
+          email: 'test@example.com',
+          boxes: ['INBOX'],
+          fetchEmailBody: false,
+          cleaningEnabled: false,
+          fetcherClient: mockFetcher,
+          googleContactsSync: true
+        },
+        pipelineDeps
+      );
+
+      expect(pipeline.getTask(TaskId.Fetch)).toBeDefined();
+      expect(pipeline.getTask(TaskId.GoogleContactsFetch)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Extract)).toBeDefined();
+    });
+
+    it('should create pipeline with FetchTask + ExtractTask (no GoogleContactsFetchTask) when boxes: ["INBOX"] + googleContactsSync: false', () => {
+      const mockFetcher = {
+        startFetch: jest
+          .fn()
+          .mockResolvedValue({ data: { totalMessages: 100 } } as never),
+        stopFetch: jest.fn<() => Promise<void>>().mockResolvedValue()
+      } as unknown as FetcherClient;
+
+      const pipeline = createImapMining(
+        {
+          miningId: 'test-folders-only',
+          userId: 'user-1',
+          email: 'test@example.com',
+          boxes: ['INBOX'],
+          fetchEmailBody: false,
+          cleaningEnabled: false,
+          fetcherClient: mockFetcher,
+          googleContactsSync: false
+        },
+        pipelineDeps
+      );
+
+      expect(pipeline.getTask(TaskId.Fetch)).toBeDefined();
+      expect(pipeline.getTask(TaskId.Extract)).toBeDefined();
+      expect(pipeline.getTask(TaskId.GoogleContactsFetch)).toBeUndefined();
     });
   });
 });

--- a/backend/test/unit/validators/mining.schema.test.ts
+++ b/backend/test/unit/validators/mining.schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from '@jest/globals';
+import { startMiningSchema } from '../../../src/validators/mining.schema';
+
+describe('startMiningSchema', () => {
+  describe('boxes + googleContactsSync validation', () => {
+    it('should accept boxes: [] when googleContactsSync: true', () => {
+      const result = startMiningSchema.safeParse({
+        params: { userId: 'user-1' },
+        body: {
+          miningSource: { email: 'test@example.com' },
+          boxes: [],
+          googleContactsSync: true,
+          cleaningEnabled: false,
+          extractSignatures: false
+        }
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject boxes: [] when googleContactsSync: false', () => {
+      const result = startMiningSchema.safeParse({
+        params: { userId: 'user-1' },
+        body: {
+          miningSource: { email: 'test@example.com' },
+          boxes: [],
+          googleContactsSync: false,
+          cleaningEnabled: false,
+          extractSignatures: false
+        }
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('boxes');
+      }
+    });
+
+    it('should reject boxes: [] when googleContactsSync is undefined', () => {
+      const result = startMiningSchema.safeParse({
+        params: { userId: 'user-1' },
+        body: {
+          miningSource: { email: 'test@example.com' },
+          boxes: [],
+          cleaningEnabled: false,
+          extractSignatures: false
+        }
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('boxes');
+      }
+    });
+
+    it('should accept boxes: ["INBOX"] when googleContactsSync: true', () => {
+      const result = startMiningSchema.safeParse({
+        params: { userId: 'user-1' },
+        body: {
+          miningSource: { email: 'test@example.com' },
+          boxes: ['INBOX'],
+          googleContactsSync: true,
+          cleaningEnabled: false,
+          extractSignatures: false
+        }
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept boxes: ["INBOX"] when googleContactsSync: false', () => {
+      const result = startMiningSchema.safeParse({
+        params: { userId: 'user-1' },
+        body: {
+          miningSource: { email: 'test@example.com' },
+          boxes: ['INBOX'],
+          googleContactsSync: false,
+          cleaningEnabled: false,
+          extractSignatures: false
+        }
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
+++ b/frontend/src/components/mining/stepper-panels/mine/MinePanel.vue
@@ -46,11 +46,7 @@
     <Button
       v-if="!$leadminerStore.activeMiningTask"
       id="mine-stepper-start-button"
-      :disabled="
-        (sourceType === 'email' &&
-          ($leadminerStore.isLoadingBoxes || totalEmails === 0)) ||
-        $leadminerStore.isLoadingStartMining
-      "
+      :disabled="!canStartMining"
       :loading="$leadminerStore.isLoadingStartMining"
       :label="$t('common.start_mining_now')"
       @click="startMining"
@@ -242,6 +238,13 @@ const selectedBoxes = computed<TreeSelectionKeys>(
 
 const taskStartedAt = computed(() => $leadminerStore.miningStartedAt);
 
+const hasSelectedBoxes = computed(
+  () =>
+    Object.keys(selectedBoxes.value).filter(
+      (key) => selectedBoxes.value[key].checked && key !== '',
+    ).length > 0,
+);
+
 const sourceTypeIsEmail = computed(
   () => sourceType.value === 'email' || sourceType.value === 'pst',
 );
@@ -289,6 +292,13 @@ const totalMinedMessage = computed(() =>
 
 const extractionFinished = computed(() => $leadminerStore.extractionFinished);
 const extractedEmails = computed(() => $leadminerStore.extractedEmails);
+
+const canStartMining = computed(() => {
+  if (sourceType.value !== 'email') return true;
+  if ($leadminerStore.isLoadingBoxes || $leadminerStore.isLoadingStartMining)
+    return false;
+  return totalEmails.value > 0 || $leadminerStore.googleContactsSyncEnabled;
+});
 
 const extractionProgress = computed(() =>
   $leadminerStore.fetchingFinished && !canceled.value
@@ -390,6 +400,24 @@ watch(extractionFinished, async (finished) => {
   }
 });
 
+watch(
+  () => $leadminerStore.googleContactsFetched,
+  async (fetched) => {
+    if (fetched && !canceled.value && !hasSelectedBoxes.value) {
+      $toast.add({
+        severity: 'info',
+        summary: t('mining_done'),
+        detail: totalExtractedNotificationMessage.value,
+        group: 'achievement',
+        life: 8000,
+      });
+      $stepper.next();
+      if (isSupported.value && permissionGranted.value) show();
+      await reloadContacts();
+    }
+  },
+);
+
 function openMiningSettings() {
   if (sourceType.value === 'email' || sourceType.value === 'pst') {
     miningSettingsDialogRef.value!.open(); // skipcq: JS-0339 is component ref
@@ -398,6 +426,7 @@ function openMiningSettings() {
 
 async function startMiningBoxes() {
   if (
+    !$leadminerStore.googleContactsSyncEnabled &&
     Object.keys(selectedBoxes.value).filter(
       (key) => selectedBoxes.value[key].checked && key !== '',
     ).length === 0


### PR DESCRIPTION
## Summary

Allow users to start a mining pipeline with **Google Contacts only** (no IMAP folders required). Previously, `startMiningSchema` required a non-empty `boxes` array; now an empty `boxes` is accepted when `googleContactsSync` is enabled.

- resolves #2863 

## Changes

- **`startMiningSchema`** — `boxes` is now `.default([])`; new refinement rejects empty `boxes` when `googleContactsSync` is missing/false.
- **`createImapMining` factory** — skips `FetchTask` / `SignatureTask` when `boxes` is empty; gracefully handles a no-upstream `Extract` task by only adding the progress link when at least one source is present.
- **`MinePanel.vue`** — new `canStartMining` computed enables the start button when Google Contacts sync is on, even with no boxes. New watcher surfaces a success toast when the Google Contacts fetch finishes without any folder selection.
- **`.gitignore`** — ignore `.slim/deepwork/` (local opencode state).

## Tests

- 5 new unit cases for `startMiningSchema` (accepts/rejects combinations of `boxes` × `googleContactsSync`).
- 4 new integration cases for the pipeline shape: GC-only, GC+clean, combined (IMAP+GC), folders-only.

All targeted tests pass: `5/5` unit, `10/10` integration. Backend full suite (`598/598`) and pre-push lint/prettier pass.

## How to test

- Start a mining source with `googleContactsSync: true` and `boxes: []` → pipeline should run with `GoogleContactsFetchTask` + `ExtractTask` only.
- Start with `googleContactsSync: false` and `boxes: []` → request rejected with `boxes must be non-empty when Google Contacts sync is disabled`.
- Frontend: enable the Google Contacts toggle in Mining Settings with no folders selected → "Start mining" should be enabled.
