### PR TITLE
fix(senders): tri-state active badge with live availability, refresh after test

### DIFF
--- a/backend/src/controllers/smtp-senders.controller.ts
+++ b/backend/src/controllers/smtp-senders.controller.ts
@@ -219,20 +219,39 @@ export default function initializeSmtpSendersController(
         });
 
         try {
-          await transport.sendMail({
+          const result = await transport.sendMail({
             from: `"${sender.name}" <${sender.email}>`,
             to: testTo,
             subject: 'Leadminer SMTP Test',
-            text: 'This is a test email from Leadminer to verify your SMTP configuration.'
+            text: 'This is a test email from Leadminer to verify your SMTP configuration.',
           });
 
+          if (!result) {
+            await smtpSenders.update(req.params.id, user.id, { active: false });
+            return res.status(400).json({
+              success: false,
+              message: 'SMTP transport returned no result',
+            });
+          }
+
           return res.json({ success: true, message: 'Test email sent' });
+        } catch (error) {
+          await smtpSenders
+            .update(req.params.id, user.id, { active: false })
+            .catch((updateError) => {
+              logger.warn('Failed to mark sender inactive after SMTP test failure', {
+                senderId: req.params.id,
+                userId: user.id,
+                error: updateError instanceof Error ? updateError.message : String(updateError),
+              });
+            });
+          const message = error instanceof Error ? error.message : 'Test failed';
+          return res.status(400).json({ success: false, message });
         } finally {
           transport.close();
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Test failed';
-        return res.status(400).json({ success: false, message });
+        return next(error);
       }
     },
 

--- a/frontend/src/components/senders/EmailSenderManagement.vue
+++ b/frontend/src/components/senders/EmailSenderManagement.vue
@@ -94,6 +94,7 @@ defineExpose({ openAddDialog });
 
 onMounted(async () => {
   await $store.fetchSenders();
+  await $store.fetchSenderAvailability();
   if ($store.senders.length === 0) {
     await $store.regenerateFromSources();
   }
@@ -167,9 +168,20 @@ onMounted(async () => {
             @click="confirmDelete(sender)"
           />
           <Tag
-            :value="sender.active ? t('active') : t('inactive')"
-            :severity="sender.active ? 'success' : 'secondary'"
+            v-if="
+              sender.active &&
+              $store.availability[sender.email.toLowerCase()] !== false
+            "
+            :value="t('active')"
+            severity="success"
           />
+          <Tag
+            v-else-if="sender.active"
+            v-tooltip.top="t('active_stale_tooltip')"
+            :value="t('active_stale')"
+            severity="warn"
+          />
+          <Tag v-else :value="t('inactive')" severity="secondary" />
         </div>
       </div>
     </div>
@@ -177,7 +189,9 @@ onMounted(async () => {
     <AddEmailSenderDialog
       v-model:visible="showAddDialog"
       :editing-sender="editingSender"
-      @sender-saved="$store.fetchSenders()"
+      @sender-saved="
+        $store.fetchSenders().then(() => $store.fetchSenderAvailability())
+      "
     />
   </div>
 </template>
@@ -189,6 +203,8 @@ onMounted(async () => {
     "no_senders_configured": "No email senders configured",
     "active": "Active",
     "inactive": "Inactive",
+    "active_stale": "Stale",
+    "active_stale_tooltip": "Saved as active but the last live SMTP/OAuth check failed. Click Test to retry.",
     "edit": "Edit",
     "test": "Test",
     "delete": "Delete",
@@ -205,6 +221,8 @@ onMounted(async () => {
     "no_senders_configured": "Aucun expéditeur email configuré",
     "active": "Actif",
     "inactive": "Inactif",
+    "active_stale": "Obsolète",
+    "active_stale_tooltip": "Enregistré comme actif mais la dernière vérification SMTP/OAuth a échoué. Cliquez sur Tester pour réessayer.",
     "edit": "Modifier",
     "test": "Tester",
     "delete": "Supprimer",

--- a/frontend/src/stores/smtp-senders.ts
+++ b/frontend/src/stores/smtp-senders.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/types/smtp-senders';
 
 export const useSmtpSendersStore = defineStore('smtp-senders', () => {
-  const { $api } = useNuxtApp();
+  const { $api, $saasEdgeFunctions } = useNuxtApp();
 
   const senders = ref<SmtpSender[]>([]);
   const isLoading = ref(false);
@@ -132,6 +132,8 @@ export const useSmtpSendersStore = defineStore('smtp-senders', () => {
         success: false,
         message: err instanceof Error ? err.message : 'Test failed',
       };
+    } finally {
+      await fetchSenders();
     }
   }
 
@@ -169,6 +171,33 @@ export const useSmtpSendersStore = defineStore('smtp-senders', () => {
 
   const activeSenders = computed(() => senders.value.filter((s) => s.active));
 
+  const availability = ref<Record<string, boolean>>({});
+
+  async function fetchSenderAvailability(): Promise<void> {
+    try {
+      const response = await $saasEdgeFunctions(
+        'email-campaigns/campaigns/sender-options',
+        { method: 'POST', body: {} },
+      );
+      const options: Array<{ email?: string; available?: boolean }> =
+        response?.options ?? [];
+      const next: Record<string, boolean> = {};
+      for (const option of options) {
+        const email = String(option.email ?? '')
+          .trim()
+          .toLowerCase();
+        if (email) {
+          next[email] = Boolean(option.available);
+        }
+      }
+      availability.value = next;
+    } catch (err) {
+      // Silent failure — stale availability is better than broken UI
+      error.value =
+        err instanceof Error ? err.message : 'Failed to fetch availability';
+    }
+  }
+
   function $reset() {
     senders.value = [];
     isLoading.value = false;
@@ -180,6 +209,7 @@ export const useSmtpSendersStore = defineStore('smtp-senders', () => {
     isLoading,
     error,
     activeSenders,
+    availability,
     fetchSenders,
     createSender,
     updateSender,
@@ -187,6 +217,7 @@ export const useSmtpSendersStore = defineStore('smtp-senders', () => {
     testSender,
     autodetect,
     regenerateFromSources,
+    fetchSenderAvailability,
     $reset,
   };
 });


### PR DESCRIPTION
## Fix for today's demo bug: sender "connected" in settings vs "disconnected" in campaign composer

### Problem
Two bugs surfaced during today's demo around sender management:

**Bug A — sender state divergence**
A sender (e.g. `bader.lejmi@gmail.com`) shows as **"Active"** in the sender management settings page (`/account/settings` → Email Sender Management) but appears as **"unavailable"** with a reconnect prompt in the campaign composer. There is no explanation for the divergence — the user has no way to tell whether their SMTP/OAuth is broken or whether it's just a stale UI state.

**Bug B — failing test leaves stale "Active" state**
Clicking the "Test" button in sender management runs an SMTP test, but:
- The backend never updates `sender.active` in the DB on failure → the sender stays "Active" in the list
- The frontend never refreshes after the test → even if the backend updated, the UI wouldn't reflect it

Result: a sender whose SMTP is broken still shows "Active" until the user reloads the page, and even then nothing has changed.

### Root cause
- **Bug A:** Two independent state machines with no sync — `sender.active` (DB column, set by user) vs `option.available` (live transport check computed at request time in `supabase/functions/email-campaigns/index.ts:resolveSenderOptions`). The UI only showed `sender.active`, ignoring the live availability signal.
- **Bug B:** `backend/src/controllers/smtp-senders.controller.ts:testSender` returned success/failure but never touched `smtp_senders.active`. Frontend store's `testSender` action didn't reload the list.

### Fix

**Backend** (`backend/src/controllers/smtp-senders.controller.ts`):
- `testSender` now calls `smtpSenders.update(id, userId, { active: false })` when `transport.sendMail` returns falsy OR throws. The outer `try/catch` wraps the inner block so unexpected errors still propagate to `next(err)`.

**Frontend store** (`frontend/src/stores/smtp-senders.ts`):
- `testSender` action now calls `await fetchSenders()` in a `finally` block, refreshing the canonical DB state after every test (success or failure).
- Added new `availability` reactive ref (`Record<string, boolean>`) and `fetchSenderAvailability()` action that calls the same `email-campaigns/campaigns/sender-options` endpoint the campaign composer uses, populating the map by sender email.

**Frontend component** (`frontend/src/components/senders/EmailSenderManagement.vue`):
- The sender badge is now **tri-state**:
  - Green `success` — `active && availability[email] !== false` (active + live verified)
  - Amber `warn` with tooltip — `active && availability[email] === false` (saved as active but last live check failed; tooltip tells user to click Test to retry)
  - Grey `secondary` — `!active` (inactive)
- `onMounted` now calls `fetchSenderAvailability()` after `fetchSenders()`.
- `@sender-saved` handler now also refreshes availability.

**i18n** (en + fr): added `active_stale` ("Stale" / "Obsolète") and `active_stale_tooltip` strings.

### Files changed
- `backend/src/controllers/smtp-senders.controller.ts` (+22 / -6)
- `frontend/src/components/senders/EmailSenderManagement.vue` (+22 / -3)
- `frontend/src/stores/smtp-senders.ts` (+33 / -1)
- `deno.lock` (prettier auto-format)

### Testing
- Manual: open `/account/settings` → Email Sender Management; observe badge state for each sender. Edit credentials of an OAuth sender, observe amber "Stale" badge with tooltip. Click Test, observe badge stays in sync.
- Backend unit tests in `backend/test/unit/smtp-senders/` should still pass — the `testSender` signature is unchanged.

### Related
- Today's demo bug: email campaigns failing because of billing edge function outage — fixed by PR #964 (leadminer.io) and PR #121 (leadminer-commercial). This PR fixes the sender UX bugs from the same demo session.