### PR TITLE
feat(contacts): realtime reconcile via stable contact_id + mining-active raw streaming

### DIFF
--- a/frontend/src/components/mining/table/MiningTable.vue
+++ b/frontend/src/components/mining/table/MiningTable.vue
@@ -125,7 +125,7 @@
           "
         >
           <RemoveContactButton
-            :contacts-to-delete="contactsToTreat"
+            :contacts-to-delete="contactsToDelete"
             :contacts-to-delete-length="selectedContactsLength"
             :is-remove-disabled="isExportDisabled || !selectedContactsLength"
             :deselect-contacts="deselectContacts"
@@ -1270,6 +1270,18 @@ const contactsToTreat = computed<string[] | undefined>(() =>
   implicitSelectAll.value
     ? undefined
     : implicitlySelectedContacts.value.map((item: Contact) => item.id),
+);
+
+// Delete must remove EVERY member of a merged contact, not just its primary
+// person. `contactsToTreat` maps to `item.id` (primary person) which would leave
+// orphan members that re-materialize the contact after delete. Flatten all
+// person_ids instead.
+const contactsToDelete = computed<string[] | undefined>(() =>
+  implicitSelectAll.value
+    ? undefined
+    : implicitlySelectedContacts.value.flatMap((item: Contact) =>
+        item.person_ids?.length ? item.person_ids : [item.id],
+      ),
 );
 
 const updateSelectedIds = useDebounceFn((ids: string[] | undefined) => {

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -19,6 +19,7 @@ import Normalizer from '~/utils/normalizer';
 import { useLeadminerStore } from './leadminer';
 
 const REALTIME_DEBOUNCE_MS = 700;
+const REALTIME_RECONCILE_MAX_RETRIES = 3;
 
 export const useContactsStore = defineStore('contacts-store', () => {
   const $user = useSupabaseUser();
@@ -46,6 +47,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
 
   let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
   let reconciling = false;
+  let reconcileRetryCount = 0;
   const pendingReconcilePersonIds = new Set<string>();
 
   /**
@@ -193,8 +195,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
       void flushRealtimeReconcile();
     }, REALTIME_DEBOUNCE_MS);
   }
-
-  async function flushRealtimeReconcile() {
+async function flushRealtimeReconcile() {
     if (reconciling) {
       scheduleReconcile();
       return;
@@ -207,7 +208,6 @@ export const useContactsStore = defineStore('contacts-store', () => {
       if ($leadminerStore.activeMiningTask) return;
 
       const ids = [...pendingReconcilePersonIds];
-      pendingReconcilePersonIds.clear();
       if (ids.length === 0) return;
 
       const { data, error } = await $supabase
@@ -218,8 +218,12 @@ export const useContactsStore = defineStore('contacts-store', () => {
         });
       if (error) throw error;
 
+      // RPC succeeded — safe to drop the buffered ids.
+      pendingReconcilePersonIds.clear();
+
       const reconciled = data as Contact[];
       const cached = [...contactsCacheMap.values()];
+
       const { upserts, prunes } = applyReconciledContacts(
         cached,
         ids,
@@ -233,8 +237,16 @@ export const useContactsStore = defineStore('contacts-store', () => {
         await updateContactsCache(row);
       }
       updateContactList.value = true;
+      reconcileRetryCount = 0;
     } catch (e) {
       console.warn('Failed to reconcile contacts from realtime', e);
+      // The buffered ids were not cleared (clear happens only after a
+      // successful RPC), so a transient failure retries the same groups.
+      const retried = reconcileRetryCount + 1;
+      if (retried < REALTIME_RECONCILE_MAX_RETRIES) {
+        reconcileRetryCount = retried;
+        scheduleReconcile();
+      }
     } finally {
       reconciling = false;
     }

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -14,6 +14,8 @@ import {
   applyReconciledContacts,
   collectRealtimePersonIds,
   getContactKey,
+  resolveRealtimeAction,
+  type RealtimePersonRow,
 } from '~/utils/contacts-realtime';
 import Normalizer from '~/utils/normalizer';
 import { useLeadminerStore } from './leadminer';
@@ -302,21 +304,32 @@ async function flushRealtimeReconcile() {
         filter: `user_id=eq.${userId}`,
       },
       (
-        payload: RealtimePostgresChangesPayload<{
-          id?: string;
-          email?: string | null;
-        }>,
+        payload: RealtimePostgresChangesPayload<RealtimePersonRow>,
       ) => {
-        const ids = collectRealtimePersonIds(payload);
-        if (ids.length === 0) return;
-
         if (!getCurrentUserId()) return;
-        if ($leadminerStore.activeMiningTask) return;
 
-        for (const id of ids) {
-          pendingReconcilePersonIds.add(id);
+        const action = resolveRealtimeAction(payload, {
+          activeMining: $leadminerStore.activeMiningTask,
+        });
+
+        switch (action.kind) {
+          case 'stream':
+            void updateContactsCache(action.row as unknown as Contact);
+            updateContactList.value = true;
+            return;
+          case 'remove':
+            removeOldContacts([action.id]);
+            updateContactList.value = true;
+            return;
+          case 'reconcile':
+            for (const id of action.personIds) {
+              pendingReconcilePersonIds.add(id);
+            }
+            scheduleReconcile();
+            return;
+          case 'none':
+            return;
         }
-        scheduleReconcile();
       },
     );
     realtimeChannelUserId = userId;

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -122,7 +122,9 @@ export const useContactsStore = defineStore('contacts-store', () => {
     const contacts = await loadContacts();
     contacts
       .toReversed()
-      .forEach((contact) => contactsCacheMap.set(getContactKey(contact), contact));
+      .forEach((contact) =>
+        contactsCacheMap.set(getContactKey(contact), contact),
+      );
     updateContactList.value = true;
     syncContactsList();
   }
@@ -197,7 +199,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
       flushRealtimeReconcile();
     }, REALTIME_DEBOUNCE_MS);
   }
-async function flushRealtimeReconcile() {
+  async function flushRealtimeReconcile() {
     if (reconciling) {
       scheduleReconcile();
       return;
@@ -285,15 +287,11 @@ async function flushRealtimeReconcile() {
 
     realtimeChannel = $supabase.channel(`contacts-table-${userId}`);
 
-    realtimeChannel.on(
-      'system',
-      { event: 'reconnected' },
-      () => {
-        console.debug('Realtime reconnected — reloading contacts');
-        pendingReconcilePersonIds.clear();
-        reloadContacts();
-      },
-    );
+    realtimeChannel.on('system', { event: 'reconnected' }, () => {
+      console.debug('Realtime reconnected — reloading contacts');
+      pendingReconcilePersonIds.clear();
+      reloadContacts();
+    });
 
     realtimeChannel.on(
       'postgres_changes',
@@ -303,9 +301,7 @@ async function flushRealtimeReconcile() {
         table: 'persons',
         filter: `user_id=eq.${userId}`,
       },
-      (
-        payload: RealtimePostgresChangesPayload<RealtimePersonRow>,
-      ) => {
+      (payload: RealtimePostgresChangesPayload<RealtimePersonRow>) => {
         if (!getCurrentUserId()) return;
 
         const action = resolveRealtimeAction(payload, {

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -106,7 +106,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
       .rpc('get_contacts_table', { p_user_id: userId });
 
     if (error) throw error;
-    return data as Contact[];
+    return data as unknown as Contact[];
   }
 
   /**
@@ -221,7 +221,7 @@ async function flushRealtimeReconcile() {
       // RPC succeeded — safe to drop the buffered ids.
       pendingReconcilePersonIds.clear();
 
-      const reconciled = data as Contact[];
+      const reconciled = data as unknown as Contact[];
       const cached = [...contactsCacheMap.values()];
 
       const { upserts, prunes } = applyReconciledContacts(

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -10,11 +10,20 @@ import {
   type TableOrigin,
 } from '~/utils/table-preferences';
 import { convertDates } from '~/utils/contacts';
+import {
+  applyReconciledContacts,
+  collectRealtimePersonIds,
+  getContactKey,
+} from '~/utils/contacts-realtime';
 import Normalizer from '~/utils/normalizer';
+import { useLeadminerStore } from './leadminer';
+
+const REALTIME_DEBOUNCE_MS = 700;
 
 export const useContactsStore = defineStore('contacts-store', () => {
   const $user = useSupabaseUser();
   const $supabase = useSupabaseClient();
+  const $leadminerStore = useLeadminerStore();
 
   const updateContactList = ref<boolean>(false);
   const contactsCacheMap = new Map<string, Contact>();
@@ -34,6 +43,10 @@ export const useContactsStore = defineStore('contacts-store', () => {
   let realtimeChannel: RealtimeChannel | null = null;
   let realtimeChannelUserId: string | null = null;
   let syncIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconciling = false;
+  const pendingReconcilePersonIds = new Set<string>();
 
   /**
    * Applies cached contacts to the main contacts list.
@@ -98,12 +111,14 @@ export const useContactsStore = defineStore('contacts-store', () => {
    * Loads contacts from db and restarts SyncInterval.
    */
   async function reloadContacts() {
+    pendingReconcilePersonIds.clear();
+    clearReconcileTimer();
     updateContactList.value = false;
     contactsCacheMap.clear();
     const contacts = await loadContacts();
     contacts
       .toReversed()
-      .forEach((contact) => contactsCacheMap.set(contact.id, contact));
+      .forEach((contact) => contactsCacheMap.set(getContactKey(contact), contact));
     updateContactList.value = true;
     syncContactsList();
   }
@@ -127,8 +142,8 @@ export const useContactsStore = defineStore('contacts-store', () => {
   ) {
     const clean: Contact = JSON.parse(JSON.stringify(newContact));
 
-    const { id } = clean;
-    const existingContact = contactsCacheMap.get(id);
+    const key = getContactKey(clean);
+    const existingContact = contactsCacheMap.get(key);
     const updatedContact = existingContact
       ? { ...existingContact, ...clean }
       : clean;
@@ -146,19 +161,83 @@ export const useContactsStore = defineStore('contacts-store', () => {
     }
 
     if (keepPosition) {
-      contactsCacheMap.set(updatedContact.id, updatedContact);
+      contactsCacheMap.set(getContactKey(updatedContact), updatedContact);
     } else {
       // Remove and reinsert to change position in the Map
-      contactsCacheMap.delete(id);
-      contactsCacheMap.set(id, updatedContact);
+      contactsCacheMap.delete(key);
+      contactsCacheMap.set(key, updatedContact);
     }
   }
 
-  function removeOldContact(id: string) {
-    contactsCacheMap.delete(id);
+  function removeContactsByKeys(keys: string[]) {
+    const keySet = new Set(keys);
+    if (keySet.size === 0) return;
+    for (const key of keySet) {
+      contactsCacheMap.delete(key);
+    }
     contactsList.value = contactsList.value?.filter(
-      (contact) => contact.id !== id,
+      (contact) => !keySet.has(getContactKey(contact)),
     );
+  }
+
+  function clearReconcileTimer() {
+    if (reconcileTimer) {
+      clearTimeout(reconcileTimer);
+      reconcileTimer = null;
+    }
+  }
+
+  function scheduleReconcile() {
+    clearReconcileTimer();
+    reconcileTimer = setTimeout(() => {
+      void flushRealtimeReconcile();
+    }, REALTIME_DEBOUNCE_MS);
+  }
+
+  async function flushRealtimeReconcile() {
+    if (reconciling) {
+      scheduleReconcile();
+      return;
+    }
+    reconciling = true;
+    clearReconcileTimer();
+    const userId = getCurrentUserId();
+    try {
+      if (!userId) return;
+      if ($leadminerStore.activeMiningTask) return;
+
+      const ids = [...pendingReconcilePersonIds];
+      pendingReconcilePersonIds.clear();
+      if (ids.length === 0) return;
+
+      const { data, error } = await $supabase
+        .schema('private')
+        .rpc('get_contacts_view_by_ids', {
+          p_user_id: userId,
+          p_person_ids: ids,
+        });
+      if (error) throw error;
+
+      const reconciled = data as Contact[];
+      const cached = [...contactsCacheMap.values()];
+      const { upserts, prunes } = applyReconciledContacts(
+        cached,
+        ids,
+        reconciled,
+      );
+
+      for (const key of prunes) {
+        removeContactsByKeys([key]);
+      }
+      for (const row of upserts) {
+        await updateContactsCache(row);
+      }
+      updateContactList.value = true;
+    } catch (e) {
+      console.warn('Failed to reconcile contacts from realtime', e);
+    } finally {
+      reconciling = false;
+    }
   }
 
   function removeOldContacts(ids?: string[]) {
@@ -190,7 +269,19 @@ export const useContactsStore = defineStore('contacts-store', () => {
 
     if (realtimeChannel) return;
 
-    realtimeChannel = $supabase.channel(`contacts-table-${userId}`).on(
+    realtimeChannel = $supabase.channel(`contacts-table-${userId}`);
+
+    realtimeChannel.on(
+      'system',
+      { event: 'reconnected' },
+      () => {
+        console.debug('Realtime reconnected — reloading contacts');
+        pendingReconcilePersonIds.clear();
+        void reloadContacts();
+      },
+    );
+
+    realtimeChannel.on(
       'postgres_changes',
       {
         event: '*',
@@ -198,19 +289,22 @@ export const useContactsStore = defineStore('contacts-store', () => {
         table: 'persons',
         filter: `user_id=eq.${userId}`,
       },
-      (payload: RealtimePostgresChangesPayload<Contact>) => {
-        if (payload.eventType === 'DELETE' && payload.old.id) {
-          removeOldContact(payload.old.id);
-        } else if (payload.new as Contact) {
-          setTimeout(async () => {
-            try {
-              await updateContactsCache(payload.new as Contact);
-            } catch (e) {
-              console.warn('Failed to update contacts cache from realtime', e);
-            }
-            updateContactList.value = true;
-          }, 0);
+      (
+        payload: RealtimePostgresChangesPayload<{
+          id?: string;
+          email?: string | null;
+        }>,
+      ) => {
+        const ids = collectRealtimePersonIds(payload);
+        if (ids.length === 0) return;
+
+        if (!getCurrentUserId()) return;
+        if ($leadminerStore.activeMiningTask) return;
+
+        for (const id of ids) {
+          pendingReconcilePersonIds.add(id);
         }
+        scheduleReconcile();
       },
     );
     realtimeChannelUserId = userId;
@@ -222,6 +316,8 @@ export const useContactsStore = defineStore('contacts-store', () => {
    * Unsubscribes from real-time updates and clears the sync interval.
    */
   async function unsubscribeFromRealtimeUpdates() {
+    pendingReconcilePersonIds.clear();
+    clearReconcileTimer();
     await syncContactsList();
 
     if (realtimeChannel) {
@@ -399,5 +495,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
     getLocationsToNormalize,
     updateContactsCache,
     setSkipOrgLookup,
+    clearReconcileTimer,
+    collectRealtimePersonIds,
   };
 });

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -194,7 +194,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
   function scheduleReconcile() {
     clearReconcileTimer();
     reconcileTimer = setTimeout(() => {
-      void flushRealtimeReconcile();
+      flushRealtimeReconcile();
     }, REALTIME_DEBOUNCE_MS);
   }
 async function flushRealtimeReconcile() {
@@ -291,7 +291,7 @@ async function flushRealtimeReconcile() {
       () => {
         console.debug('Realtime reconnected — reloading contacts');
         pendingReconcilePersonIds.clear();
-        void reloadContacts();
+        reloadContacts();
       },
     );
 
@@ -314,7 +314,7 @@ async function flushRealtimeReconcile() {
 
         switch (action.kind) {
           case 'stream':
-            void updateContactsCache(action.row as unknown as Contact);
+            updateContactsCache(action.row as unknown as Contact);
             updateContactList.value = true;
             return;
           case 'remove':
@@ -328,6 +328,8 @@ async function flushRealtimeReconcile() {
             scheduleReconcile();
             return;
           case 'none':
+            return;
+          default:
             return;
         }
       },

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -3,6 +3,7 @@ import {
   applyReconciledContacts,
   collectRealtimePersonIds,
   getContactKey,
+  resolveRealtimeAction,
 } from '@/utils/contacts-realtime';
 import type { Contact } from '@/types/contact';
 
@@ -81,5 +82,66 @@ describe('applyReconciledContacts', () => {
     const { upserts, prunes } = applyReconciledContacts(cached, ['p1'], []);
     expect(prunes).toEqual([]);
     expect(upserts).toEqual([]);
+  });
+});
+
+describe('resolveRealtimeAction', () => {
+  it('streams a raw INSERT row while mining is active', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'INSERT', new: { id: 'p1', name: 'Mined', email: 'm@x.com' } },
+      { activeMining: true },
+    );
+    expect(action.kind).toBe('stream');
+    if (action.kind === 'stream') {
+      expect(action.row.id).toBe('p1');
+    }
+  });
+
+  it('streams a raw UPDATE row while mining is active', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'UPDATE', old: { id: 'p1' }, new: { id: 'p1', name: 'NewName' } },
+      { activeMining: true },
+    );
+    expect(action.kind).toBe('stream');
+  });
+
+  it('removes by person id on DELETE while mining is active', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'DELETE', old: { id: 'p1' } },
+      { activeMining: true },
+    );
+    expect(action).toEqual({ kind: 'remove', id: 'p1' });
+  });
+
+  it('returns none for a mining DELETE without an old id', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'DELETE', old: null },
+      { activeMining: true },
+    );
+    expect(action.kind).toBe('none');
+  });
+
+  it('buffers person ids for merged reconcile outside mining', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'INSERT', new: { id: 'p1' } },
+      { activeMining: false },
+    );
+    expect(action).toEqual({ kind: 'reconcile', personIds: ['p1'] });
+  });
+
+  it('reconciles old+new ids on UPDATE outside mining', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'UPDATE', old: { id: 'old' }, new: { id: 'new' } },
+      { activeMining: false },
+    );
+    expect(action).toEqual({ kind: 'reconcile', personIds: ['old', 'new'] });
+  });
+
+  it('reconciles the old id on DELETE outside mining', () => {
+    const action = resolveRealtimeAction(
+      { eventType: 'DELETE', old: { id: 'p1' } },
+      { activeMining: false },
+    );
+    expect(action).toEqual({ kind: 'reconcile', personIds: ['p1'] });
   });
 });

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -76,4 +76,10 @@ describe('applyReconciledContacts', () => {
     expect(upserts).toHaveLength(1);
     expect(prunes).toEqual(['a@b.c']);
   });
+  it('does not prune a buffered key that is not currently cached', () => {
+    const cached = [contact({ id: 'z', email: 'keep@b.c' })];
+    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c'], []);
+    expect(prunes).toEqual([]);
+    expect(upserts).toEqual([]);
+  });
 });

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -7,7 +7,9 @@ import {
 } from '@/utils/contacts-realtime';
 import type { Contact } from '@/types/contact';
 
-function contact(partial: Partial<Contact> & { id: string; contact_id?: string }): Contact {
+function contact(
+  partial: Partial<Contact> & { id: string; contact_id?: string },
+): Contact {
   const cid = partial.contact_id ?? `cid-${partial.id}`;
   return {
     user_id: 'u1',
@@ -31,13 +33,17 @@ function contact(partial: Partial<Contact> & { id: string; contact_id?: string }
 
 describe('getContactKey', () => {
   it('keys a contact by its stable contact_id', () => {
-    expect(getContactKey(contact({ id: 'a', contact_id: 'cid-a' }))).toBe('cid-a');
+    expect(getContactKey(contact({ id: 'a', contact_id: 'cid-a' }))).toBe(
+      'cid-a',
+    );
   });
 });
 
 describe('collectRealtimePersonIds', () => {
   it('INSERT buffers the new row id', () => {
-    expect(collectRealtimePersonIds({ eventType: 'INSERT', new: { id: 'p1' } })).toEqual(['p1']);
+    expect(
+      collectRealtimePersonIds({ eventType: 'INSERT', new: { id: 'p1' } }),
+    ).toEqual(['p1']);
   });
   it('UPDATE buffers both old and new ids', () => {
     const ids = collectRealtimePersonIds({
@@ -49,11 +55,17 @@ describe('collectRealtimePersonIds', () => {
   });
   it('UPDATE same id dedupes', () => {
     expect(
-      collectRealtimePersonIds({ eventType: 'UPDATE', old: { id: 'p1' }, new: { id: 'p1' } }),
+      collectRealtimePersonIds({
+        eventType: 'UPDATE',
+        old: { id: 'p1' },
+        new: { id: 'p1' },
+      }),
     ).toEqual(['p1']);
   });
   it('DELETE buffers the old id', () => {
-    expect(collectRealtimePersonIds({ eventType: 'DELETE', old: { id: 'p1' } })).toEqual(['p1']);
+    expect(
+      collectRealtimePersonIds({ eventType: 'DELETE', old: { id: 'p1' } }),
+    ).toEqual(['p1']);
   });
 });
 
@@ -61,9 +73,18 @@ describe('applyReconciledContacts', () => {
   it('returns reconciled groups as upserts and no prunes when they still exist', () => {
     const cached = [contact({ id: 'x', contact_id: 'c1', person_ids: ['p1'] })];
     const reconciled = [
-      contact({ id: 'y', contact_id: 'c1', person_ids: ['p1', 'p2'], name: 'Merged' }),
+      contact({
+        id: 'y',
+        contact_id: 'c1',
+        person_ids: ['p1', 'p2'],
+        name: 'Merged',
+      }),
     ];
-    const { upserts, prunes } = applyReconciledContacts(cached, ['p1'], reconciled);
+    const { upserts, prunes } = applyReconciledContacts(
+      cached,
+      ['p1'],
+      reconciled,
+    );
     expect(upserts).toEqual(reconciled);
     expect(prunes).toEqual([]);
   });
@@ -88,7 +109,10 @@ describe('applyReconciledContacts', () => {
 describe('resolveRealtimeAction', () => {
   it('streams a raw INSERT row while mining is active', () => {
     const action = resolveRealtimeAction(
-      { eventType: 'INSERT', new: { id: 'p1', name: 'Mined', email: 'm@x.com' } },
+      {
+        eventType: 'INSERT',
+        new: { id: 'p1', name: 'Mined', email: 'm@x.com' },
+      },
       { activeMining: true },
     );
     expect(action.kind).toBe('stream');
@@ -99,7 +123,11 @@ describe('resolveRealtimeAction', () => {
 
   it('streams a raw UPDATE row while mining is active', () => {
     const action = resolveRealtimeAction(
-      { eventType: 'UPDATE', old: { id: 'p1' }, new: { id: 'p1', name: 'NewName' } },
+      {
+        eventType: 'UPDATE',
+        old: { id: 'p1' },
+        new: { id: 'p1', name: 'NewName' },
+      },
       { activeMining: true },
     );
     expect(action.kind).toBe('stream');

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyReconciledContacts,
+  collectRealtimeKeys,
+  getContactKey,
+} from '@/utils/contacts-realtime';
+import type { Contact } from '@/types/contact';
+
+function contact(partial: Partial<Contact> & { id: string; email?: string | null }): Contact {
+  return {
+    user_id: 'u1',
+    name: null,
+    given_name: null,
+    family_name: null,
+    alternate_name: null,
+    telephone: null,
+    location: null,
+    location_normalized: null,
+    works_for: null,
+    job_title: null,
+    same_as: null,
+    image: null,
+    status: null,
+    temperature: null,
+    ...partial,
+  };
+}
+
+describe('getContactKey', () => {
+  it('keys email contacts by their email (lowercased)', () => {
+    expect(getContactKey(contact({ id: 'a', email: 'Foo@Bar.com' }))).toBe('foo@bar.com');
+  });
+  it('keys phone-only contacts by their id', () => {
+    expect(getContactKey(contact({ id: 'p1', email: null }))).toBe('p1');
+  });
+});
+
+describe('collectRealtimeKeys', () => {
+  it('INSERT buffers the new row key', () => {
+    expect(collectRealtimeKeys({ eventType: 'INSERT', new: { id: 'x', email: 'A@b.c' } })).toEqual(['a@b.c']);
+  });
+  it('UPDATE buffers both old and new keys (email rename)', () => {
+    const keys = collectRealtimeKeys({
+      eventType: 'UPDATE',
+      old: { id: 'x', email: 'A@b.c' },
+      new: { id: 'x', email: 'd@e.f' },
+    });
+    expect(keys.sort()).toEqual(['a@b.c', 'd@e.f']);
+  });
+  it('DELETE buffers the old key, falling back to id when email missing', () => {
+    expect(
+      collectRealtimeKeys({ eventType: 'DELETE', old: { id: 'p1', email: null } }),
+    ).toEqual(['p1']);
+    expect(
+      collectRealtimeKeys({ eventType: 'DELETE', old: { id: 'x', email: 'a@b.c' } }),
+    ).toEqual(['a@b.c']);
+  });
+});
+
+describe('applyReconciledContacts', () => {
+  it('returns only upserts for rows that still exist', () => {
+    const cached = [contact({ id: 'x', email: 'a@b.c' })];
+    const reconciled = [contact({ id: 'y', email: 'a@b.c', name: 'New Primary' })];
+    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c'], reconciled);
+    expect(upserts).toEqual(reconciled);
+    expect(prunes).toEqual([]);
+  });
+  it('prunes buffered keys that no longer exist in the view', () => {
+    const cached = [
+      contact({ id: 'x', email: 'a@b.c' }),
+      contact({ id: 'z', email: 'keep@b.c' }),
+    ];
+    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c', 'keep@b.c'], [
+      contact({ id: 'z', email: 'keep@b.c' }),
+    ]);
+    expect(upserts).toHaveLength(1);
+    expect(prunes).toEqual(['a@b.c']);
+  });
+});

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyReconciledContacts,
-  collectRealtimeKeys,
+  collectRealtimePersonIds,
   getContactKey,
 } from '@/utils/contacts-realtime';
 import type { Contact } from '@/types/contact';
 
-function contact(partial: Partial<Contact> & { id: string; email?: string | null }): Contact {
+function contact(partial: Partial<Contact> & { id: string; contact_id?: string }): Contact {
+  const cid = partial.contact_id ?? `cid-${partial.id}`;
   return {
     user_id: 'u1',
+    contact_id: cid,
     name: null,
     given_name: null,
     family_name: null,
@@ -27,58 +29,56 @@ function contact(partial: Partial<Contact> & { id: string; email?: string | null
 }
 
 describe('getContactKey', () => {
-  it('keys email contacts by their email (lowercased)', () => {
-    expect(getContactKey(contact({ id: 'a', email: 'Foo@Bar.com' }))).toBe('foo@bar.com');
-  });
-  it('keys phone-only contacts by their id', () => {
-    expect(getContactKey(contact({ id: 'p1', email: null }))).toBe('p1');
+  it('keys a contact by its stable contact_id', () => {
+    expect(getContactKey(contact({ id: 'a', contact_id: 'cid-a' }))).toBe('cid-a');
   });
 });
 
-describe('collectRealtimeKeys', () => {
-  it('INSERT buffers the new row key', () => {
-    expect(collectRealtimeKeys({ eventType: 'INSERT', new: { id: 'x', email: 'A@b.c' } })).toEqual(['a@b.c']);
+describe('collectRealtimePersonIds', () => {
+  it('INSERT buffers the new row id', () => {
+    expect(collectRealtimePersonIds({ eventType: 'INSERT', new: { id: 'p1' } })).toEqual(['p1']);
   });
-  it('UPDATE buffers both old and new keys (email rename)', () => {
-    const keys = collectRealtimeKeys({
+  it('UPDATE buffers both old and new ids', () => {
+    const ids = collectRealtimePersonIds({
       eventType: 'UPDATE',
-      old: { id: 'x', email: 'A@b.c' },
-      new: { id: 'x', email: 'd@e.f' },
+      old: { id: 'p-old' },
+      new: { id: 'p-new' },
     });
-    expect(keys.sort()).toEqual(['a@b.c', 'd@e.f']);
+    expect(ids.sort()).toEqual(['p-new', 'p-old']);
   });
-  it('DELETE buffers the old key, falling back to id when email missing', () => {
+  it('UPDATE same id dedupes', () => {
     expect(
-      collectRealtimeKeys({ eventType: 'DELETE', old: { id: 'p1', email: null } }),
+      collectRealtimePersonIds({ eventType: 'UPDATE', old: { id: 'p1' }, new: { id: 'p1' } }),
     ).toEqual(['p1']);
-    expect(
-      collectRealtimeKeys({ eventType: 'DELETE', old: { id: 'x', email: 'a@b.c' } }),
-    ).toEqual(['a@b.c']);
+  });
+  it('DELETE buffers the old id', () => {
+    expect(collectRealtimePersonIds({ eventType: 'DELETE', old: { id: 'p1' } })).toEqual(['p1']);
   });
 });
 
 describe('applyReconciledContacts', () => {
-  it('returns only upserts for rows that still exist', () => {
-    const cached = [contact({ id: 'x', email: 'a@b.c' })];
-    const reconciled = [contact({ id: 'y', email: 'a@b.c', name: 'New Primary' })];
-    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c'], reconciled);
+  it('returns reconciled groups as upserts and no prunes when they still exist', () => {
+    const cached = [contact({ id: 'x', contact_id: 'c1', person_ids: ['p1'] })];
+    const reconciled = [
+      contact({ id: 'y', contact_id: 'c1', person_ids: ['p1', 'p2'], name: 'Merged' }),
+    ];
+    const { upserts, prunes } = applyReconciledContacts(cached, ['p1'], reconciled);
     expect(upserts).toEqual(reconciled);
     expect(prunes).toEqual([]);
   });
-  it('prunes buffered keys that no longer exist in the view', () => {
+  it('prunes a cached contact whose member person was removed and group vanished', () => {
     const cached = [
-      contact({ id: 'x', email: 'a@b.c' }),
-      contact({ id: 'z', email: 'keep@b.c' }),
+      contact({ id: 'x', contact_id: 'c1', person_ids: ['p1'] }),
+      contact({ id: 'z', contact_id: 'c2', person_ids: ['p9'] }),
     ];
-    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c', 'keep@b.c'], [
-      contact({ id: 'z', email: 'keep@b.c' }),
-    ]);
-    expect(upserts).toHaveLength(1);
-    expect(prunes).toEqual(['a@b.c']);
+    const { upserts, prunes } = applyReconciledContacts(cached, ['p1'], []);
+    expect(upserts).toEqual([]);
+    expect(prunes).toEqual(['c1']);
+    expect(prunes).not.toContain('c2');
   });
-  it('does not prune a buffered key that is not currently cached', () => {
-    const cached = [contact({ id: 'z', email: 'keep@b.c' })];
-    const { upserts, prunes } = applyReconciledContacts(cached, ['a@b.c'], []);
+  it('does not prune a cached contact unaffected by the buffered person ids', () => {
+    const cached = [contact({ id: 'z', contact_id: 'c2', person_ids: ['p9'] })];
+    const { upserts, prunes } = applyReconciledContacts(cached, ['p1'], []);
     expect(prunes).toEqual([]);
     expect(upserts).toEqual([]);
   });

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -20,6 +20,8 @@ export interface NormalizedLocation {
 }
 export interface Contact {
   id: string;
+  contact_id?: string;
+  person_ids?: string[];
   user_id: string;
   email?: string | null;
   name: string | null;

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -36,8 +36,8 @@ export interface Contact {
   same_as: string[] | null;
   image: string | null;
   engagement?: number;
-  sender?: string;
-  recipient?: string;
+  sender?: number;
+  recipient?: number;
   conversations?: number;
   replied_conversations?: number;
   status: EmailStatus | null;

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -1533,6 +1533,7 @@ export type Database = {
           alternate_name: string[];
           consent_changed_at: string;
           consent_status: Database['private']['Enums']['contact_consent_status'];
+          contact_id: string;
           conversations: number;
           created_at: string;
           email: string;
@@ -1547,6 +1548,7 @@ export type Database = {
           mining_id: string;
           name: string;
           occurrence: number;
+          person_ids: string[];
           recency: string;
           recipient: number;
           replied_conversations: number;
@@ -1564,13 +1566,14 @@ export type Database = {
           works_for: string;
         }[];
       };
-      get_contacts_table_by_emails: {
-        Args: { p_emails: string[]; p_user_id: string };
+      get_contacts_view_by_ids: {
+        Args: { p_person_ids: string[]; p_user_id: string };
         Returns: {
           alternate_email: string[];
           alternate_name: string[];
           consent_changed_at: string;
           consent_status: Database['private']['Enums']['contact_consent_status'];
+          contact_id: string;
           conversations: number;
           created_at: string;
           email: string;
@@ -1585,6 +1588,7 @@ export type Database = {
           mining_id: string;
           name: string;
           occurrence: number;
+          person_ids: string[];
           recency: string;
           recipient: number;
           replied_conversations: number;

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -1564,6 +1564,44 @@ export type Database = {
           works_for: string;
         }[];
       };
+      get_contacts_table_by_emails: {
+        Args: { p_emails: string[]; p_user_id: string };
+        Returns: {
+          alternate_email: string[];
+          alternate_name: string[];
+          consent_changed_at: string;
+          consent_status: Database['private']['Enums']['contact_consent_status'];
+          conversations: number;
+          created_at: string;
+          email: string;
+          family_name: string;
+          given_name: string;
+          id: string;
+          identifier: string;
+          image: string;
+          job_title: string;
+          location: string;
+          location_normalized: Json;
+          mining_id: string;
+          name: string;
+          occurrence: number;
+          recency: string;
+          recipient: number;
+          replied_conversations: number;
+          same_as: string[];
+          sender: number;
+          seniority: string;
+          sources: string[];
+          status: string;
+          tags: string[];
+          telephone: string[];
+          temperature: number;
+          updated_at: string;
+          user_id: string;
+          user_tags: string[];
+          works_for: string;
+        }[];
+      };
       get_contacts_table_by_ids: {
         Args: { p_ids: string[]; p_user_id: string };
         Returns: {

--- a/frontend/src/utils/contacts-realtime.ts
+++ b/frontend/src/utils/contacts-realtime.ts
@@ -30,7 +30,9 @@ type RealtimeRow = RealtimePersonRow;
  * the cache key. It does NOT change when person membership or the primary
  * person changes.
  */
-export function getContactKey(contact: Pick<Contact, 'contact_id' | 'id'>): string {
+export function getContactKey(
+  contact: Pick<Contact, 'contact_id' | 'id'>,
+): string {
   return contact.contact_id ?? contact.id;
 }
 

--- a/frontend/src/utils/contacts-realtime.ts
+++ b/frontend/src/utils/contacts-realtime.ts
@@ -4,48 +4,62 @@ type RealtimeRow = { id?: string; email?: string | null };
 
 /**
  * Stable identity for a merged contact group.
- * Email contacts merge under their email; phone-only persons never merge so
- * their person id is the group key.
+ * The DB exposes contact.contact_id (deterministic uuid per group) — this is
+ * the cache key. It does NOT change when person membership or the primary
+ * person changes.
  */
-export function getContactKey(contact: Pick<Contact, 'id' | 'email'>): string {
-  return contact.email ? contact.email.toLowerCase() : contact.id;
+export function getContactKey(contact: Pick<Contact, 'contact_id' | 'id'>): string {
+  return contact.contact_id ?? contact.id;
 }
 
 /**
- * Derive the group keys a realtime payload must re-read.
- * Identity transitions (email rename, group member deleted) require both the
- * old and the new key so the pre- and post-change groups are both reconciled.
+ * Collect the person_id(s) a realtime payload signals changed. These are the
+ * keys used to reverse-lookup the affected aggregate group(s) via
+ * get_contacts_view_by_ids.
+ *
+ * - INSERT / UPDATE buffer the NEW row's person id.
+ * - UPDATE / DELETE also buffer the OLD row's person id (covers the case where
+ *   the id itself changes, and any rename on the person).
  */
-export function collectRealtimeKeys(payload: {
+export function collectRealtimePersonIds(payload: {
   eventType: 'INSERT' | 'UPDATE' | 'DELETE';
   new?: RealtimeRow | null;
   old?: RealtimeRow | null;
 }): string[] {
-  const keys = new Set<string>();
+  const ids = new Set<string>();
   const push = (row?: RealtimeRow | null) => {
-    if (!row || !row.id) return;
-    keys.add(row.email ? row.email.toLowerCase() : row.id);
+    if (row?.id) ids.add(row.id);
   };
   if (payload.eventType !== 'INSERT') push(payload.old);
   if (payload.eventType !== 'DELETE') push(payload.new);
-  return [...keys];
+  return [...ids];
 }
 
 /**
- * Apply the freshly read merge rows to the cache decision.
- * Rows returned by get_contacts_table_by_emails are upserts. Any buffered key
- * that no longer exists in the view means its group was deleted (or renamed
- * away) and must be pruned from the cache.
+ * Decide which cache entries to upsert vs prune after re-reading contacts.
+ *
+ * `reconciled` = the aggregate groups returned by get_contacts_view_by_ids for
+ * the buffered `personIds`. Their rows carry person_ids which we use to know a
+ * cached contact was touched.
+ *
+ * - upserts: all reconciled groups (fresh merged state).
+ * - prunes: cached contacts whose person_ids overlap the buffered ids but that
+ *   were NOT returned — i.e. their last member was removed, or the group
+ *   disappeared. Contacts with no overlap are untouched.
  */
 export function applyReconciledContacts(
   cached: Contact[],
-  bufferedKeys: string[],
+  bufferedPersonIds: string[],
   reconciled: Contact[],
 ): { upserts: Contact[]; prunes: string[] } {
-  const bufferedSet = new Set(bufferedKeys);
+  const bufferedSet = new Set(bufferedPersonIds);
   const reconciledKeys = new Set(reconciled.map(getContactKey));
   const prunes = cached
-    .filter((c) => bufferedSet.has(getContactKey(c)) && !reconciledKeys.has(getContactKey(c)))
+    .filter(
+      (c) =>
+        (c.person_ids ?? []).some((pid) => bufferedSet.has(pid)) &&
+        !reconciledKeys.has(getContactKey(c)),
+    )
     .map(getContactKey);
   return { upserts: reconciled, prunes };
 }

--- a/frontend/src/utils/contacts-realtime.ts
+++ b/frontend/src/utils/contacts-realtime.ts
@@ -1,0 +1,51 @@
+import type { Contact } from '@/types/contact';
+
+type RealtimeRow = { id?: string; email?: string | null };
+
+/**
+ * Stable identity for a merged contact group.
+ * Email contacts merge under their email; phone-only persons never merge so
+ * their person id is the group key.
+ */
+export function getContactKey(contact: Pick<Contact, 'id' | 'email'>): string {
+  return contact.email ? contact.email.toLowerCase() : contact.id;
+}
+
+/**
+ * Derive the group keys a realtime payload must re-read.
+ * Identity transitions (email rename, group member deleted) require both the
+ * old and the new key so the pre- and post-change groups are both reconciled.
+ */
+export function collectRealtimeKeys(payload: {
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+  new?: RealtimeRow | null;
+  old?: RealtimeRow | null;
+}): string[] {
+  const keys = new Set<string>();
+  const push = (row?: RealtimeRow | null) => {
+    if (!row || !row.id) return;
+    keys.add(row.email ? row.email.toLowerCase() : row.id);
+  };
+  if (payload.eventType !== 'INSERT') push(payload.old);
+  if (payload.eventType !== 'DELETE') push(payload.new);
+  return [...keys];
+}
+
+/**
+ * Apply the freshly read merge rows to the cache decision.
+ * Rows returned by get_contacts_table_by_emails are upserts. Any buffered key
+ * that no longer exists in the view means its group was deleted (or renamed
+ * away) and must be pruned from the cache.
+ */
+export function applyReconciledContacts(
+  cached: Contact[],
+  bufferedKeys: string[],
+  reconciled: Contact[],
+): { upserts: Contact[]; prunes: string[] } {
+  const bufferedSet = new Set(bufferedKeys);
+  const reconciledKeys = new Set(reconciled.map(getContactKey));
+  const prunes = cached
+    .filter((c) => bufferedSet.has(getContactKey(c)) && !reconciledKeys.has(getContactKey(c)))
+    .map(getContactKey);
+  return { upserts: reconciled, prunes };
+}

--- a/frontend/src/utils/contacts-realtime.ts
+++ b/frontend/src/utils/contacts-realtime.ts
@@ -1,6 +1,28 @@
 import type { Contact } from '@/types/contact';
 
-type RealtimeRow = { id?: string; email?: string | null };
+export type RealtimePersonRow = {
+  id?: string;
+  email?: string | null;
+  name?: string | null;
+  source?: string | null;
+  telephone?: string[] | null;
+  location?: string | null;
+  works_for?: string | null;
+  job_title?: string | null;
+  given_name?: string | null;
+  family_name?: string | null;
+  image?: string | null;
+  alternate_name?: string[] | null;
+  same_as?: string[] | null;
+  alternate_email?: string[] | null;
+  status?: string | null;
+  consent_status?: string | null;
+  consent_changed_at?: string | null;
+  updated_at?: string | null;
+  created_at?: string | null;
+};
+
+type RealtimeRow = RealtimePersonRow;
 
 /**
  * Stable identity for a merged contact group.
@@ -62,4 +84,43 @@ export function applyReconciledContacts(
     )
     .map(getContactKey);
   return { upserts: reconciled, prunes };
+}
+
+/**
+ * Decide how the contacts store should react to a realtime person event.
+ *
+ * - During active mining: stream raw person rows (keyed by person id) so newly
+ *   mined people appear live. The post-mining reloadContacts() performs a full
+ *   contacts_view load that migrates the cache to the merged logic.
+ * - Outside mining: buffer person ids for the debounced merged reconcile.
+ *
+ * Returns a discriminated action the store dispatches.
+ */
+export type RealtimeAction =
+  | { kind: 'stream'; row: RealtimePersonRow }
+  | { kind: 'remove'; id: string }
+  | { kind: 'reconcile'; personIds: string[] }
+  | { kind: 'none' };
+
+export function resolveRealtimeAction(
+  payload: {
+    eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+    new?: RealtimePersonRow | null;
+    old?: RealtimePersonRow | null;
+  },
+  opts: { activeMining: boolean },
+): RealtimeAction {
+  if (opts.activeMining) {
+    if (payload.eventType === 'DELETE' && payload.old?.id) {
+      return { kind: 'remove', id: payload.old.id };
+    }
+    if (payload.new?.id) {
+      return { kind: 'stream', row: payload.new };
+    }
+    return { kind: 'none' };
+  }
+
+  const personIds = collectRealtimePersonIds(payload);
+  if (personIds.length === 0) return { kind: 'none' };
+  return { kind: 'reconcile', personIds };
 }

--- a/supabase/migrations/20260821010000_persons_replica_identity_full.sql
+++ b/supabase/migrations/20260821010000_persons_replica_identity_full.sql
@@ -1,0 +1,6 @@
+-- Realtime reconciliation of contacts relies on knowing which email-group a
+-- changed persons row belonged to. Default replica identity (primary key) only
+-- carries the id, so DELETE/UPDATE payloads lack old.email and deleted/renamed
+-- groups could never be re-read from contacts_view. FULL identity makes the
+-- whole old row available on DELETE and UPDATE.
+ALTER TABLE private.persons REPLICA IDENTITY FULL;

--- a/supabase/migrations/20260821020000_contacts_view_stable_id_person_ids.sql
+++ b/supabase/migrations/20260821020000_contacts_view_stable_id_person_ids.sql
@@ -1,0 +1,332 @@
+-- Add a stable aggregate identity (contact_id) and the member person_ids to
+-- private.contacts_view so the frontend can:
+--   1. key the contacts cache by a STABLE contact id (not the mutable primary
+--      person id), eliminating duplicate/vanishing rows on realtime changes;
+--   2. reverse-lookup a merged contact from a single person_id realtime event.
+--
+-- contact_id is deterministic (uuid_generate_v5 over the stable group key
+-- COALESCE(email, id::text)); it does NOT depend on which person ranks first,
+-- so it is stable across view recomputes. person_ids is the ordered list of
+-- member person ids for reverse lookups.
+
+-- ---------------------------------------------------------------------------
+-- 1. Recreate contacts_view with contact_id + person_ids
+-- ---------------------------------------------------------------------------
+DROP VIEW IF EXISTS private.contacts_view;
+
+CREATE VIEW private.contacts_view WITH (security_invoker = true) AS
+WITH ordered_sources AS (
+    SELECT
+        id,
+        email,
+        user_id,
+        source,
+        name,
+        alternate_name,
+        telephone,
+        same_as,
+        alternate_email,
+        works_for,
+        updated_at,
+        created_at,
+        mining_id,
+        image,
+        location,
+        location_normalized,
+        consent_status,
+        consent_changed_at,
+        given_name,
+        family_name,
+        job_title,
+        status,
+        ROW_NUMBER() OVER (
+            PARTITION BY COALESCE(email, id::text), user_id
+            ORDER BY (source NOT LIKE '%:%') DESC, updated_at DESC
+        ) AS rn
+    FROM private.persons
+),
+
+all_names AS (
+    SELECT
+        COALESCE(email, id::text) AS group_key,
+        user_id,
+        array_agg(DISTINCT name)     FILTER (WHERE name IS NOT NULL)     AS distinct_names,
+        array_agg(DISTINCT alt_name) FILTER (WHERE alt_name IS NOT NULL) AS distinct_alt_names
+    FROM ordered_sources
+    LEFT JOIN LATERAL unnest(alternate_name) AS alt_name ON true
+    GROUP BY COALESCE(email, id::text), user_id
+),
+
+primary_name AS (
+    SELECT DISTINCT ON (COALESCE(email, id::text), user_id)
+        COALESCE(email, id::text) AS group_key,
+        user_id,
+        name AS primary_name
+    FROM ordered_sources
+    WHERE name IS NOT NULL
+    ORDER BY COALESCE(email, id::text), user_id, rn
+),
+
+telephone_agg AS (
+    SELECT
+        COALESCE(email, id::text) AS group_key,
+        user_id,
+        array_agg(DISTINCT tel) FILTER (WHERE tel IS NOT NULL) AS telephone
+    FROM ordered_sources, unnest(telephone) AS tel
+    GROUP BY COALESCE(email, id::text), user_id
+),
+
+same_as_agg AS (
+    SELECT
+        COALESCE(email, id::text) AS group_key,
+        user_id,
+        array_agg(DISTINCT sa) FILTER (WHERE sa IS NOT NULL) AS same_as
+    FROM ordered_sources, unnest(same_as) AS sa
+    GROUP BY COALESCE(email, id::text), user_id
+),
+
+alternate_email_agg AS (
+    SELECT
+        COALESCE(email, id::text) AS group_key,
+        user_id,
+        array_agg(DISTINCT a_email) FILTER (WHERE a_email IS NOT NULL) AS alternate_email
+    FROM ordered_sources, unnest(alternate_email) AS a_email
+    GROUP BY COALESCE(email, id::text), user_id
+),
+
+merged AS (
+    SELECT
+        COALESCE(os.email, os.id::text)                                  AS group_key,
+        os.email,
+        os.user_id,
+        (array_agg(os.id ORDER BY os.rn))[1]                            AS id,
+        array_agg(DISTINCT os.id ORDER BY os.id)                        AS person_ids,
+        array_agg(DISTINCT os.source ORDER BY os.source)               AS sources,
+        COALESCE(pn.primary_name, '')                                  AS name,
+        (
+            SELECT array_agg(DISTINCT n)
+            FROM unnest(an.distinct_names || an.distinct_alt_names) AS n
+            WHERE n IS NOT NULL
+              AND n <> COALESCE(pn.primary_name, '')
+        )                                                                AS alternate_name,
+        (array_agg(os.status             ORDER BY os.rn) FILTER (WHERE os.status             IS NOT NULL))[1] AS status,
+        (array_agg(os.consent_status     ORDER BY os.rn) FILTER (WHERE os.consent_status     IS NOT NULL))[1] AS consent_status,
+        (array_agg(os.consent_changed_at ORDER BY os.rn) FILTER (WHERE os.consent_changed_at IS NOT NULL))[1] AS consent_changed_at,
+        (array_agg(os.image              ORDER BY os.rn) FILTER (WHERE os.image              IS NOT NULL))[1] AS image,
+        (array_agg(os.location           ORDER BY os.rn) FILTER (WHERE os.location           IS NOT NULL))[1] AS location,
+        (array_agg(os.location_normalized ORDER BY os.rn) FILTER (WHERE os.location_normalized IS NOT NULL))[1] AS location_normalized,
+        (array_agg(os.given_name         ORDER BY os.rn) FILTER (WHERE os.given_name         IS NOT NULL))[1] AS given_name,
+        (array_agg(os.family_name        ORDER BY os.rn) FILTER (WHERE os.family_name        IS NOT NULL))[1] AS family_name,
+        (array_agg(os.job_title          ORDER BY os.rn) FILTER (WHERE os.job_title          IS NOT NULL))[1] AS job_title,
+        (array_agg(os.works_for          ORDER BY os.rn) FILTER (WHERE os.works_for          IS NOT NULL))[1] AS works_for,
+        MAX(os.updated_at)                                              AS updated_at,
+        MIN(os.created_at)                                              AS created_at,
+        (array_agg(os.mining_id ORDER BY os.rn) FILTER (WHERE os.mining_id IS NOT NULL))[1] AS mining_id
+    FROM ordered_sources os
+    JOIN all_names an ON an.group_key = COALESCE(os.email, os.id::text) AND an.user_id = os.user_id
+    LEFT JOIN primary_name pn ON pn.group_key = COALESCE(os.email, os.id::text) AND pn.user_id = os.user_id
+    GROUP BY COALESCE(os.email, os.id::text), os.email, os.user_id, pn.primary_name,
+             an.distinct_names, an.distinct_alt_names
+)
+
+SELECT
+    uuid_generate_v5(
+        '00000000-0000-4000-8000-000000000000',
+        m.group_key || '|' || m.user_id::text
+    )                                                                    AS contact_id,
+    m.id,
+    m.person_ids,
+    m.sources,
+    m.email,
+    COALESCE(m.email, t.telephone[1])                                    AS identifier,
+    m.user_id,
+    m.name,
+    m.alternate_name,
+    m.given_name,
+    m.family_name,
+    m.job_title,
+    m.works_for,
+    m.image,
+    m.location,
+    m.location_normalized,
+    m.status,
+    m.consent_status,
+    m.consent_changed_at,
+    COALESCE(t.telephone,        '{}'::text[]) AS telephone,
+    COALESCE(s.same_as,          '{}'::text[]) AS same_as,
+    COALESCE(a.alternate_email,  '{}'::text[]) AS alternate_email,
+    m.updated_at,
+    m.created_at,
+    m.mining_id
+FROM merged m
+LEFT JOIN telephone_agg       t ON t.group_key = m.group_key AND t.user_id = m.user_id
+LEFT JOIN same_as_agg         s ON s.group_key = m.group_key AND s.user_id = m.user_id
+LEFT JOIN alternate_email_agg a ON a.group_key = m.group_key AND a.user_id = m.user_id;
+
+GRANT SELECT ON private.contacts_view TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. Recreate get_contacts_table exposing contact_id + person_ids
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS private.get_contacts_table(uuid);
+
+CREATE OR REPLACE FUNCTION private.get_contacts_table(p_user_id uuid)
+RETURNS TABLE(
+    contact_id            uuid,
+    id                    uuid,
+    person_ids            uuid[],
+    sources               text[],
+    email                 text,
+    identifier            text,
+    user_id               uuid,
+    name                  text,
+    status                text,
+    consent_status        private.contact_consent_status,
+    consent_changed_at    timestamptz,
+    image                 text,
+    location              text,
+    location_normalized   jsonb,
+    alternate_name        text[],
+    alternate_email       text[],
+    telephone             text[],
+    same_as               text[],
+    given_name            text,
+    family_name           text,
+    job_title             text,
+    works_for             text,
+    recency               timestamptz,
+    seniority             timestamptz,
+    occurrence            integer,
+    temperature           integer,
+    sender                integer,
+    recipient             integer,
+    conversations         integer,
+    replied_conversations integer,
+    tags                  text[],
+    user_tags             text[],
+    updated_at            timestamptz,
+    created_at            timestamptz,
+    mining_id             text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+    SELECT
+        cv.contact_id,
+        cv.id,
+        cv.person_ids,
+        cv.sources,
+        cv.email,
+        cv.identifier,
+        cv.user_id,
+        cv.name,
+        cv.status,
+        cv.consent_status,
+        cv.consent_changed_at,
+        cv.image,
+        cv.location,
+        cv.location_normalized,
+        cv.alternate_name,
+        cv.alternate_email,
+        cv.telephone,
+        cv.same_as,
+        cv.given_name,
+        cv.family_name,
+        cv.job_title,
+        o.name          AS works_for,
+        rp.recency,
+        rp.seniority,
+        rp.occurrence,
+        rp.temperature,
+        rp.sender,
+        rp.recipient,
+        rp.conversations,
+        rp.replied_conversations,
+        rp.tags,
+        rp.user_tags,
+        cv.updated_at,
+        cv.created_at,
+        cv.mining_id
+    FROM private.contacts_view cv
+    LEFT JOIN private.refinedpersons rp
+        ON rp.person_id = cv.id AND rp.user_id = cv.user_id
+    LEFT JOIN private.organizations o
+        ON o.id = cv.works_for::uuid
+    WHERE cv.user_id = p_user_id
+    ORDER BY rp.temperature DESC NULLS LAST,
+             rp.occurrence  DESC NULLS LAST,
+             rp.recency     DESC NULLS LAST;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Replace the reverse-lookup functions with a person-id based one.
+--    get_contacts_view_by_ids returns merged contacts whose person_ids overlap
+--    the provided person ids. This is the reverse lookup a realtime person
+--    event needs to re-read its aggregate group.
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS private.get_contacts_table_by_emails(uuid, text[]);
+DROP FUNCTION IF EXISTS private.get_contacts_table_by_ids(uuid, uuid[]);
+DROP FUNCTION IF EXISTS private.get_contacts_view_by_ids(uuid, uuid[]);
+
+CREATE OR REPLACE FUNCTION private.get_contacts_view_by_ids(
+    p_user_id uuid,
+    p_person_ids uuid[]
+)
+RETURNS TABLE(
+    contact_id          uuid,
+    id                  uuid,
+    person_ids          uuid[],
+    sources             text[],
+    email               text,
+    identifier          text,
+    user_id             uuid,
+    name                text,
+    status              text,
+    consent_status      private.contact_consent_status,
+    consent_changed_at  timestamptz,
+    image               text,
+    location            text,
+    location_normalized jsonb,
+    alternate_name      text[],
+    alternate_email     text[],
+    telephone           text[],
+    same_as             text[],
+    given_name          text,
+    family_name         text,
+    job_title           text,
+    works_for           text,
+    recency             timestamptz,
+    seniority           timestamptz,
+    occurrence          integer,
+    temperature         integer,
+    sender              integer,
+    recipient           integer,
+    conversations       integer,
+    replied_conversations integer,
+    tags                text[],
+    user_tags           text[],
+    updated_at          timestamptz,
+    created_at          timestamptz,
+    mining_id           text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+    SELECT ct.contact_id, ct.id, ct.person_ids, ct.sources, ct.email, ct.identifier, ct.user_id,
+           ct.name, ct.status, ct.consent_status, ct.consent_changed_at,
+           ct.image, ct.location, ct.location_normalized, ct.alternate_name,
+           ct.alternate_email, ct.telephone, ct.same_as, ct.given_name,
+           ct.family_name, ct.job_title, ct.works_for, ct.recency, ct.seniority,
+           ct.occurrence, ct.temperature, ct.sender, ct.recipient,
+           ct.conversations, ct.replied_conversations, ct.tags, ct.user_tags,
+           ct.updated_at, ct.created_at, ct.mining_id
+    FROM private.get_contacts_table(p_user_id) ct
+    WHERE ct.person_ids && p_person_ids
+    ORDER BY ct.temperature DESC NULLS LAST,
+             ct.occurrence  DESC NULLS LAST,
+             ct.recency     DESC NULLS LAST;
+$$;
+
+GRANT EXECUTE ON FUNCTION private.get_contacts_view_by_ids(uuid, uuid[]) TO authenticated;


### PR DESCRIPTION
## Summary
Make realtime contact reconciliation stable and durable by keying the cache on a
stable `contact_id`, and stream raw mined people live during active mining.

## Key changes
- **DB**: `contacts_view` gains deterministic `contact_id` (uuid_generate_v5 of the
  group key) + `person_ids uuid[]`; new RPC `get_contacts_view_by_ids(user_id, person_ids[])`
  for reverse lookup; `REPLICA IDENTITY FULL` on `persons`; drop obsolete by-emails funcs.
- **Store**: cache keyed by stable `contact_id`; realtime buffers `person_id` →
  700ms debounce → `get_contacts_view_by_ids` → upsert/prune by `contact_id`.
- **Mining carve-out** (`resolveRealtimeAction`): during active mining, stream raw person
  rows (keyed by person id) live; after mining completes, `reloadContacts()` migrates the
  cache to merged logic.
- **Delete fix**: removing a merged contact now flattens all `person_ids` (not just the
  primary id) so sibling members are not orphaned / the row does not re-materialize.

## Testing
- Unit: `contacts-realtime.test.ts` (8 + 7 new mining-branch tests) + `contacts-store-import` = 16/16.
- Frontend lint: 0 errors; production build exit 0.
- E2E harness (`contacts_realtime_e2e.py`): 13/13 pass (insert, 2-source merge, update,
  rename, delete, phone-only, 30-event burst, insert+delete, scale, rapid-update, mixed-case).