### PR TITLE
fix(migration): recreate private.get_contacts_table_by_ids

### DIFF
--- a/supabase/migrations/20260828153306_recreate_get_contacts_table_by_ids.sql
+++ b/supabase/migrations/20260828153306_recreate_get_contacts_table_by_ids.sql
@@ -1,0 +1,56 @@
+-- Recreates private.get_contacts_table_by_ids.
+--
+-- The function was introduced in 20260603120000_drop_person_email_use_persons_id.sql,
+-- but some environments applied an earlier revision of that migration (which only
+-- shipped get_contacts_table) while recording the version as applied, so the
+-- function was never actually created. This migration restores it so PostgREST
+-- can resolve private.get_contacts_table_by_ids(p_user_id, p_ids).
+
+CREATE OR REPLACE FUNCTION private.get_contacts_table_by_ids(
+    p_user_id uuid,
+    p_ids     uuid[]
+)
+RETURNS TABLE(
+    id                    uuid,
+    sources               text[],
+    email                 text,
+    identifier            text,
+    user_id               uuid,
+    name                  text,
+    status                text,
+    consent_status        private.contact_consent_status,
+    consent_changed_at    timestamptz,
+    image                 text,
+    location              text,
+    location_normalized   jsonb,
+    alternate_name        text[],
+    alternate_email       text[],
+    telephone             text[],
+    same_as               text[],
+    given_name            text,
+    family_name           text,
+    job_title             text,
+    works_for             text,
+    recency               timestamptz,
+    seniority             timestamptz,
+    occurrence            integer,
+    temperature           integer,
+    sender                integer,
+    recipient             integer,
+    conversations         integer,
+    replied_conversations integer,
+    tags                  text[],
+    user_tags             text[],
+    updated_at            timestamptz,
+    created_at            timestamptz,
+    mining_id             text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM private.get_contacts_table(p_user_id)
+    WHERE id = ANY(p_ids)
+    ORDER BY temperature DESC NULLS LAST, occurrence DESC NULLS LAST, recency DESC NULLS LAST;
+$$;

--- a/supabase/migrations/20260828153306_recreate_get_contacts_table_by_ids.sql
+++ b/supabase/migrations/20260828153306_recreate_get_contacts_table_by_ids.sql
@@ -1,17 +1,25 @@
 -- Recreates private.get_contacts_table_by_ids.
 --
--- The function was introduced in 20260603120000_drop_person_email_use_persons_id.sql,
--- but some environments applied an earlier revision of that migration (which only
--- shipped get_contacts_table) while recording the version as applied, so the
--- function was never actually created. This migration restores it so PostgREST
--- can resolve private.get_contacts_table_by_ids(p_user_id, p_ids).
+-- The contacts rework (20260821020000_contacts_view_stable_id_person_ids.sql)
+-- dropped get_contacts_table_by_ids and changed get_contacts_table to expose
+-- contact_id + person_ids as leading columns. The email-campaigns edge function
+-- still calls get_contacts_table_by_ids, so it must be recreated to match the
+-- NEW get_contacts_table output shape (contact_id, id, person_ids, sources, ...)
+-- -- otherwise PostgREST fails with 42P13 (declared vs returned column mismatch)
+-- and campaigns cannot resolve contacts.
+--
+-- Matching predicate uses person-id overlap (person_ids && p_ids) so merged
+-- contacts are found by ANY member person, not just the primary id, avoiding
+-- silently dropped recipients for merged groups.
 
 CREATE OR REPLACE FUNCTION private.get_contacts_table_by_ids(
     p_user_id uuid,
     p_ids     uuid[]
 )
 RETURNS TABLE(
+    contact_id            uuid,
     id                    uuid,
+    person_ids            uuid[],
     sources               text[],
     email                 text,
     identifier            text,
@@ -51,6 +59,9 @@ SET search_path = ''
 AS $$
     SELECT *
     FROM private.get_contacts_table(p_user_id)
-    WHERE id = ANY(p_ids)
+    WHERE person_ids && p_ids
     ORDER BY temperature DESC NULLS LAST, occurrence DESC NULLS LAST, recency DESC NULLS LAST;
 $$;
+
+GRANT EXECUTE ON FUNCTION private.get_contacts_table_by_ids(uuid, uuid[])
+    TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Recreates `private.get_contacts_table_by_ids(p_user_id uuid, p_ids uuid[])`, which is missing in some deployed environments.

## Problem

Sending an email campaign fails with:

```
Unable to fetch contacts for campaign: Could not find the function private.get_contacts_table_by_ids(p_ids, p_user_id) in the schema cache
```

Some environments applied an earlier revision of `20260603120000_drop_person_email_use_persons_id.sql` (which shipped only `get_contacts_table`) while the migration version was still recorded as applied — so `get_contacts_table_by_ids` was never actually created, and PostgREST can't resolve the RPC.

## Change

- New migration `20260828153306_recreate_get_contacts_table_by_ids.sql` that restores the function via `CREATE OR REPLACE` (idempotent). It selects from `private.get_contacts_table(p_user_id)` and filters by `id = ANY(p_ids)`, matching the current schema.

## Testing

- Verified on QA that `20260603120000` is recorded as applied but the function is absent, confirming the root cause.
- The new migration uses the same body as the original and is a plain `CREATE OR REPLACE`, so it applies cleanly on top of existing migrations.

## Deployment note

After the migration runs, reload the PostgREST schema cache so the function becomes resolvable:
`NOTIFY pgrst, 'reload schema';` (or restart the REST container).