### PR TITLE
feat(sms-campaigns): confirmation modal + middleware extraction for SMS composer

### DIFF
--- a/frontend/src/components/GenericComplianceDialog.vue
+++ b/frontend/src/components/GenericComplianceDialog.vue
@@ -55,6 +55,7 @@ export interface ModalData {
     available: number;
     availableAlready: number;
     reason?: string;
+    partial_continue?: 'partial_one' | 'partial_two';
   };
   buttons: ModalButton[];
 }

--- a/frontend/src/components/campaigns/SmsCampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/SmsCampaignComposerDialog.vue
@@ -600,15 +600,6 @@ const getSelectedRecipients = (): Array<{
   return recipients;
 };
 
-function handleComplianceAction(action: string, data?: ModalData['data']) {
-  if (action === 'continue_partial' && data) {
-    if (data.partial_continue === 'partial_two') {
-      partialTwo.value = true;
-    }
-    submitCampaign();
-  }
-}
-
 const submitCampaign = async () => {
   isSubmitting.value = true;
 
@@ -695,6 +686,15 @@ const submitCampaign = async () => {
     isSubmitting.value = false;
   }
 };
+
+function handleComplianceAction(action: string, data?: ModalData['data']) {
+  if (action === 'continue_partial' && data) {
+    if (data.partial_continue === 'partial_two') {
+      partialTwo.value = true;
+    }
+    submitCampaign();
+  }
+}
 
 function resetForm() {
   form.messageTemplate = '';

--- a/frontend/src/components/campaigns/SmsCampaignComposerDialog.vue
+++ b/frontend/src/components/campaigns/SmsCampaignComposerDialog.vue
@@ -224,6 +224,11 @@
       </div>
     </template>
   </Dialog>
+
+  <GenericComplianceDialog
+    ref="genericComplianceDialogRef"
+    @action="handleComplianceAction"
+  />
 </template>
 
 <script setup lang="ts">
@@ -235,6 +240,9 @@ import InputNumber from 'primevue/inputnumber';
 import InputText from 'primevue/inputtext';
 import type { Contact } from '~/types/contact';
 import FleetGatewaySelector from '~/components/sms-fleet/FleetGatewaySelector.vue';
+import GenericComplianceDialog, {
+  type ModalData,
+} from '@/components/GenericComplianceDialog.vue';
 
 const { t } = useI18n({ useScope: 'local' });
 const { t: globalT } = useI18n({ useScope: 'global' });
@@ -426,6 +434,10 @@ const dialogHeader = computed(() =>
 );
 
 const isSubmitting = ref(false);
+const partialTwo = ref(false);
+const genericComplianceDialogRef = ref<InstanceType<
+  typeof GenericComplianceDialog
+> | null>(null);
 const isSendingPreview = ref(false);
 const isPreviewDialogVisible = ref(false);
 const previewPhoneNumber = ref('');
@@ -588,6 +600,15 @@ const getSelectedRecipients = (): Array<{
   return recipients;
 };
 
+function handleComplianceAction(action: string, data?: ModalData['data']) {
+  if (action === 'continue_partial' && data) {
+    if (data.partial_continue === 'partial_two') {
+      partialTwo.value = true;
+    }
+    submitCampaign();
+  }
+}
+
 const submitCampaign = async () => {
   isSubmitting.value = true;
 
@@ -597,6 +618,9 @@ const submitCampaign = async () => {
     detail: t('keep_app_active_detail'),
     life: 8000,
   });
+
+  let shouldCloseDialog = true;
+  let showErrorToast = true;
 
   try {
     const recipients = getSelectedRecipients();
@@ -612,45 +636,61 @@ const submitCampaign = async () => {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       fleetMode: true,
       selectedGatewayIds: form.selectedGatewayIds,
+      partial_two: partialTwo.value,
     };
 
     const data = await $saasEdgeFunctions('sms-campaigns/campaigns/create', {
       method: 'POST',
       body: payload,
+      onResponse: ({ response }) => {
+        if ([402, 266, 400].includes(response.status)) {
+          const modalData = response._data as ModalData;
+
+          if (modalData?.type === 'modal') {
+            genericComplianceDialogRef.value?.openModal(modalData);
+            shouldCloseDialog = false;
+            showErrorToast = false;
+          }
+        }
+      },
     });
 
-    $toast.add({
-      severity: 'success',
-      summary: t('campaign_created'),
-      detail: t('campaign_created_detail', { count: data.recipientCount }),
-      life: 5000,
-    });
+    if (shouldCloseDialog) {
+      $toast.add({
+        severity: 'success',
+        summary: t('campaign_created'),
+        detail: t('campaign_created_detail', { count: data.recipientCount }),
+        life: 5000,
+      });
 
-    emit('campaign-created', data.campaignId);
-    isVisible.value = false;
-    resetForm();
+      emit('campaign-created', data.campaignId);
+      isVisible.value = false;
+      resetForm();
+    }
   } catch (error) {
-    const backendError = (error as { data?: Record<string, unknown> })?.data;
-    const backendCode =
-      typeof backendError?.code === 'string' ? backendError.code : '';
+    if (showErrorToast) {
+      const backendError = (error as { data?: Record<string, unknown> })?.data;
+      const backendCode =
+        typeof backendError?.code === 'string' ? backendError.code : '';
 
-    const detailParts = [
-      (typeof backendError?.error === 'string' && backendError.error) ||
-        (error instanceof Error ? error.message : String(error)),
-    ];
-    if (typeof backendError?.detail === 'string') {
-      detailParts.push(`- ${backendError.detail}`);
-    }
-    if (backendCode) {
-      detailParts.push(`(code: ${backendCode})`);
-    }
+      const detailParts = [
+        (typeof backendError?.error === 'string' && backendError.error) ||
+          (error instanceof Error ? error.message : String(error)),
+      ];
+      if (typeof backendError?.detail === 'string') {
+        detailParts.push(`- ${backendError.detail}`);
+      }
+      if (backendCode) {
+        detailParts.push(`(code: ${backendCode})`);
+      }
 
-    $toast.add({
-      severity: 'error',
-      summary: t('campaign_creation_failed'),
-      detail: detailParts.join(' '),
-      life: 5000,
-    });
+      $toast.add({
+        severity: 'error',
+        summary: t('campaign_creation_failed'),
+        detail: detailParts.join(' '),
+        life: 5000,
+      });
+    }
   } finally {
     isSubmitting.value = false;
   }
@@ -671,6 +711,7 @@ function resetForm() {
 }
 
 const onDialogShow = () => {
+  partialTwo.value = false;
   updateCharCount();
   // Load fleet gateways
   const $smsFleetStore = useSmsFleetStore();

--- a/frontend/tests/components/campaigns/SmsCampaignComposerDialog.test.ts
+++ b/frontend/tests/components/campaigns/SmsCampaignComposerDialog.test.ts
@@ -81,6 +81,21 @@ describe('SmsCampaignComposerDialog Structure Tests', () => {
     expect(componentContent).toContain(':max="200"');
     expect(componentContent).not.toContain(':max="250"');
   });
+
+  it('should include the generic compliance dialog for credits modals', () => {
+    expect(componentContent).toContain('GenericComplianceDialog');
+    expect(componentContent).toContain('handleComplianceAction');
+  });
+
+  it('should send partial_two flag on submit', () => {
+    expect(componentContent).toContain('partial_two: partialTwo.value');
+    expect(componentContent).toContain('const partialTwo = ref(false)');
+  });
+
+  it('should handle 402/266 modal responses in onResponse', () => {
+    expect(componentContent).toContain('[402, 266, 400]');
+    expect(componentContent).toContain("modalData?.type === 'modal'");
+  });
 });
 
 describe('SmsCampaignComposerDialog i18n', () => {

--- a/supabase/functions/sms-campaigns/index.ts
+++ b/supabase/functions/sms-campaigns/index.ts
@@ -715,6 +715,10 @@ app.post(
   "/campaigns/create",
   authMiddleware,
   complianceMiddleware,
+  // skipcq: JS-R1005 — Pre-existing create-handler complexity; phone validation was
+  // extracted to complianceMiddleware, remaining branches are the legacy provider,
+  // quota, recipient, and gateway-scheduling logic kept in place to avoid a behavioral
+  // rewrite. Splitting further tracked with the sibling preview-route refactor.
   async (c: Context, next: () => Promise<void>) => {
     const user = c.get("user");
     if (!user) return c.json({ error: "Unauthorized" }, 401);

--- a/supabase/functions/sms-campaigns/index.ts
+++ b/supabase/functions/sms-campaigns/index.ts
@@ -19,6 +19,7 @@ import {
 import {
   complianceMiddleware,
   createFinalResponseMiddleware,
+  type CampaignCheckData,
 } from "./middlewares-mod.ts";
 import { getLocalTimeBounds, getSmsQuota } from "./utils/quota.ts";
 import { normalizePhoneNumber } from "./utils/phone.ts";
@@ -718,14 +719,7 @@ app.post(
     const user = c.get("user");
     if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-    const checkData = c.get("campaignCheck") as
-      | {
-          filteredPhones: string[];
-          eligibleCount: number;
-          userId: string;
-          payload: Record<string, unknown>;
-        }
-      | undefined;
+    const checkData = c.get("campaignCheck") as CampaignCheckData | undefined;
 
     if (!checkData) {
       return c.json(

--- a/supabase/functions/sms-campaigns/index.ts
+++ b/supabase/functions/sms-campaigns/index.ts
@@ -16,8 +16,12 @@ import {
   type SmsGateCredentials,
   TwilioProvider,
 } from "./providers/mod.ts";
+import {
+  complianceMiddleware,
+  createFinalResponseMiddleware,
+} from "./middlewares-mod.ts";
 import { getLocalTimeBounds, getSmsQuota } from "./utils/quota.ts";
-import { isValidPhoneNumber, normalizePhoneNumber } from "./utils/phone.ts";
+import { normalizePhoneNumber } from "./utils/phone.ts";
 import { estimateSmsSegments } from "./utils/sms-segments.ts";
 import { shortenUrl } from "./utils/short-link.ts";
 import { getRegionFromTimezone } from "./utils/timezone-region.ts";
@@ -86,6 +90,7 @@ const smsCampaignCreateSchema = z.object({
   timezone: z.string().optional(),
   fleetMode: z.boolean().optional(),
   selectedGatewayIds: z.array(z.string()).optional(),
+  partial_two: z.boolean().optional(),
 });
 
 const smsgateConfigSchema = z.object({
@@ -705,364 +710,363 @@ function distributeRecipientsToGateways(
   return assignments;
 }
 
-app.post("/campaigns/create", authMiddleware, async (c: Context) => {
-  const user = c.get("user");
-  if (!user) return c.json({ error: "Unauthorized" }, 401);
+app.post(
+  "/campaigns/create",
+  authMiddleware,
+  complianceMiddleware,
+  async (c: Context, next: () => Promise<void>) => {
+    const user = c.get("user");
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-  logger.info("Creating SMS campaign", { userId: user.id });
+    const checkData = c.get("campaignCheck") as
+      | {
+          filteredPhones: string[];
+          eligibleCount: number;
+          userId: string;
+          payload: Record<string, unknown>;
+        }
+      | undefined;
 
-  const parseResult = smsCampaignCreateSchema.safeParse(
-    await c.req.json().catch(() => ({})),
-  );
-  if (!parseResult.success) {
-    return c.json(validationErrorBody(parseResult.error), 400);
-  }
-  const payload = parseResult.data;
-  const {
-    selectedPhones,
-    selectedRecipients,
-    senderName,
-    messageTemplate,
-    footerTextTemplate,
-    useShortLinks,
-    provider,
-    smsgateConfig,
-    simpleSmsGatewayConfig,
-    timezone,
-    fleetMode,
-    selectedGatewayIds,
-  } = payload;
-
-  const isFleetMode = fleetMode === true;
-
-  if (!senderName || !messageTemplate) {
-    return c.json(
-      { error: "Missing required fields", code: "MISSING_REQUIRED_FIELDS" },
-      400,
-    );
-  }
-
-  const phonesFromRecipients = (selectedRecipients || []).map((r) => r.phone);
-  const requestedPhones =
-    phonesFromRecipients.length > 0
-      ? phonesFromRecipients
-      : selectedPhones || [];
-
-  if (!requestedPhones || requestedPhones.length === 0) {
-    return c.json(
-      { error: "No recipients selected", code: "NO_RECIPIENTS" },
-      400,
-    );
-  }
-
-  const region = getRegionFromTimezone(timezone);
-  const validPhones = requestedPhones
-    .filter((phone) => isValidPhoneNumber(phone, region))
-    .map((phone) => normalizePhoneNumber(phone, region) as string);
-  const uniquePhones = [...new Set(validPhones)];
-
-  if (uniquePhones.length === 0) {
-    return c.json(
-      { error: "No valid phone numbers found", code: "NO_VALID_PHONES" },
-      400,
-    );
-  }
-
-  const userTimezone = timezone || "UTC";
-  const supabaseAdmin = createSupabaseAdmin();
-
-  // Handle Fleet Mode
-  let fleetGateways: SmsFleetGateway[] = [];
-  if (isFleetMode) {
-    if (!selectedGatewayIds || selectedGatewayIds.length === 0) {
+    if (!checkData) {
       return c.json(
-        {
-          error: "No gateways selected for fleet mode",
-          code: "NO_GATEWAYS_SELECTED",
-        },
+        { error: "Campaign check data missing", code: "INTERNAL_ERROR" },
+        500,
+      );
+    }
+
+    logger.info("Creating SMS campaign", { userId: user.id });
+
+    const parseResult = smsCampaignCreateSchema.safeParse(checkData.payload);
+    if (!parseResult.success) {
+      return c.json(validationErrorBody(parseResult.error), 400);
+    }
+    const payload = parseResult.data;
+    const {
+      selectedRecipients,
+      senderName,
+      messageTemplate,
+      footerTextTemplate,
+      useShortLinks,
+      provider,
+      smsgateConfig,
+      simpleSmsGatewayConfig,
+      timezone,
+      fleetMode,
+      selectedGatewayIds,
+    } = payload;
+
+    const isFleetMode = fleetMode === true;
+
+    if (!senderName || !messageTemplate) {
+      return c.json(
+        { error: "Missing required fields", code: "MISSING_REQUIRED_FIELDS" },
         400,
       );
     }
 
-    fleetGateways = await getUserFleetGateways(
+    const region = getRegionFromTimezone(timezone);
+    const uniquePhones = checkData.filteredPhones;
+
+    const userTimezone = timezone || "UTC";
+    const supabaseAdmin = createSupabaseAdmin();
+
+    // Handle Fleet Mode
+    let fleetGateways: SmsFleetGateway[] = [];
+    if (isFleetMode) {
+      if (!selectedGatewayIds || selectedGatewayIds.length === 0) {
+        return c.json(
+          {
+            error: "No gateways selected for fleet mode",
+            code: "NO_GATEWAYS_SELECTED",
+          },
+          400,
+        );
+      }
+
+      fleetGateways = await getUserFleetGateways(
+        supabaseAdmin,
+        user.id,
+        selectedGatewayIds,
+      );
+
+      if (fleetGateways.length === 0) {
+        return c.json(
+          {
+            error: "Selected gateways not found or inactive",
+            code: "GATEWAYS_NOT_FOUND",
+          },
+          400,
+        );
+      }
+    }
+
+    const selectedProvider = isFleetMode ? "fleet" : provider || "smsgate";
+    const smsgateUsername = smsgateConfig?.username?.trim() || "";
+    const smsgatePassword = smsgateConfig?.password?.trim() || "";
+    const smsgateBaseUrl =
+      smsgateConfig?.baseUrl?.trim() ||
+      "https://api.sms-gate.app/3rdparty/v1/messages";
+    const simpleSmsGatewayBaseUrl =
+      simpleSmsGatewayConfig?.baseUrl?.trim() ||
+      "http://192.168.1.100:8080/send-sms";
+
+    // Only validate single provider config if not in fleet mode
+    if (!isFleetMode) {
+      if (selectedProvider === "smsgate") {
+        const fields: Partial<SmsProviderProfileConfig> = {
+          smsgate_base_url: smsgateBaseUrl,
+        };
+        if (smsgateUsername) {
+          fields.smsgate_username = smsgateUsername;
+        }
+        if (smsgatePassword) {
+          fields.smsgate_password = smsgatePassword;
+        }
+        await saveProfileFields(supabaseAdmin, user.id, fields);
+      }
+
+      if (selectedProvider === "simple-sms-gateway") {
+        await saveProfileFields(supabaseAdmin, user.id, {
+          simple_sms_gateway_base_url: simpleSmsGatewayBaseUrl,
+        });
+      }
+    }
+
+    const profileConfig = await getUserSmsProviderConfig(supabaseAdmin, user.id);
+    const smsgateCredentials =
+      toSmsGateCredentials(profileConfig) ||
+      (smsgateUsername && smsgatePassword
+        ? {
+            baseUrl: smsgateBaseUrl,
+            username: smsgateUsername,
+            password: smsgatePassword,
+          }
+        : null);
+    const simpleSmsGatewayCredentials =
+      toSimpleSmsGatewayCredentials(profileConfig) ||
+      (!isFleetMode && selectedProvider === "simple-sms-gateway"
+        ? {
+            baseUrl: simpleSmsGatewayBaseUrl,
+          }
+        : null);
+
+    // Validate single provider configuration (only for non-fleet mode)
+    if (!isFleetMode) {
+      if (selectedProvider === "smsgate" && !smsgateCredentials) {
+        return c.json(
+          {
+            error:
+              "SMSGate is not configured. Please add your SMSGate credentials.",
+            code: "SMSGATE_NOT_CONFIGURED",
+          },
+          400,
+        );
+      }
+
+      if (
+        selectedProvider === "simple-sms-gateway" &&
+        !simpleSmsGatewayCredentials
+      ) {
+        return c.json(
+          {
+            error:
+              "simple-sms-gateway is not configured. Please add your credentials.",
+            code: "SIMPLE_SMS_GATEWAY_NOT_CONFIGURED",
+          },
+          400,
+        );
+      }
+
+      if (selectedProvider === "twilio" && !TwilioProvider.isConfigured()) {
+        return c.json(
+          {
+            error:
+              "Twilio is not configured. Please configure Twilio environment variables.",
+            code: "TWILIO_NOT_CONFIGURED",
+          },
+          400,
+        );
+      }
+    }
+
+    const quotaCheck = await checkSmsQuota(
       supabaseAdmin,
       user.id,
-      selectedGatewayIds,
+      uniquePhones.length,
+      userTimezone,
     );
+    if (!quotaCheck.allowed) {
+      if (quotaCheck.checkFailed) {
+        return c.json(
+          {
+            error: `Unable to verify SMS quota right now: ${quotaCheck.error}`,
+            code: "QUOTA_CHECK_FAILED",
+          },
+          500,
+        );
+      }
 
-    if (fleetGateways.length === 0) {
       return c.json(
         {
-          error: "Selected gateways not found or inactive",
-          code: "GATEWAYS_NOT_FOUND",
+          error: quotaCheck.error,
+          code: "QUOTA_EXCEEDED",
+          remainingDaily: quotaCheck.remainingDaily,
+          remainingMonthly: quotaCheck.remainingMonthly,
         },
-        400,
+        403,
       );
     }
-  }
 
-  const selectedProvider = isFleetMode ? "fleet" : provider || "smsgate";
-  const smsgateUsername = smsgateConfig?.username?.trim() || "";
-  const smsgatePassword = smsgateConfig?.password?.trim() || "";
-  const smsgateBaseUrl =
-    smsgateConfig?.baseUrl?.trim() ||
-    "https://api.sms-gate.app/3rdparty/v1/messages";
-  const simpleSmsGatewayBaseUrl =
-    simpleSmsGatewayConfig?.baseUrl?.trim() ||
-    "http://192.168.1.100:8080/send-sms";
+    const { data: campaign, error: campaignError } = await supabaseAdmin
+      .schema("private")
+      .from("sms_campaigns")
+      .insert({
+        user_id: user.id,
+        sender_name: senderName,
+        provider: selectedProvider,
+        message_template: messageTemplate,
+        footer_text_template: footerTextTemplate || null,
+        use_short_links: useShortLinks || false,
+        recipient_count: uniquePhones.length,
+        status: "queued",
+        fleet_mode_enabled: isFleetMode,
+        selected_gateway_ids: isFleetMode ? selectedGatewayIds : [],
+      })
+      .select()
+      .single();
 
-  // Only validate single provider config if not in fleet mode
-  if (!isFleetMode) {
-    if (selectedProvider === "smsgate") {
-      const fields: Partial<SmsProviderProfileConfig> = {
-        smsgate_base_url: smsgateBaseUrl,
-      };
-      if (smsgateUsername) {
-        fields.smsgate_username = smsgateUsername;
-      }
-      if (smsgatePassword) {
-        fields.smsgate_password = smsgatePassword;
-      }
-      await saveProfileFields(supabaseAdmin, user.id, fields);
-    }
-
-    if (selectedProvider === "simple-sms-gateway") {
-      await saveProfileFields(supabaseAdmin, user.id, {
-        simple_sms_gateway_base_url: simpleSmsGatewayBaseUrl,
+    if (campaignError || !campaign) {
+      logger.error("Campaign insert failed", {
+        userId: user.id,
+        errorCode: (campaignError as Record<string, unknown>)?.code,
+        errorMessage: extractErrorMessage(campaignError),
+        fullError: JSON.stringify(campaignError),
+        insertPayload: {
+          provider: selectedProvider,
+          senderName,
+          fleetMode: isFleetMode,
+        },
       });
-    }
-  }
-
-  const profileConfig = await getUserSmsProviderConfig(supabaseAdmin, user.id);
-  const smsgateCredentials =
-    toSmsGateCredentials(profileConfig) ||
-    (smsgateUsername && smsgatePassword
-      ? {
-          baseUrl: smsgateBaseUrl,
-          username: smsgateUsername,
-          password: smsgatePassword,
-        }
-      : null);
-  const simpleSmsGatewayCredentials =
-    toSimpleSmsGatewayCredentials(profileConfig) ||
-    (!isFleetMode && selectedProvider === "simple-sms-gateway"
-      ? {
-          baseUrl: simpleSmsGatewayBaseUrl,
-        }
-      : null);
-
-  // Validate single provider configuration (only for non-fleet mode)
-  if (!isFleetMode) {
-    if (selectedProvider === "smsgate" && !smsgateCredentials) {
       return c.json(
-        {
-          error:
-            "SMSGate is not configured. Please add your SMSGate credentials.",
-          code: "SMSGATE_NOT_CONFIGURED",
-        },
-        400,
+        { error: extractErrorMessage(campaignError), code: "CREATE_FAILED" },
+        500,
       );
     }
 
-    if (
-      selectedProvider === "simple-sms-gateway" &&
-      !simpleSmsGatewayCredentials
-    ) {
-      return c.json(
-        {
-          error:
-            "simple-sms-gateway is not configured. Please add your credentials.",
-          code: "SIMPLE_SMS_GATEWAY_NOT_CONFIGURED",
-        },
-        400,
-      );
+    const usedUnsubscribeTokens = new Set<string>();
+    const getNextUnsubscribeToken = () => {
+      let token = getUniqueShortToken(10);
+      while (usedUnsubscribeTokens.has(token)) {
+        token = getUniqueShortToken(10);
+      }
+      usedUnsubscribeTokens.add(token);
+      return token;
+    };
+
+    const personalizationByPhone = new Map<string, Record<string, unknown>>();
+    for (const recipient of selectedRecipients || []) {
+      const normalizedPhone = normalizePhoneNumber(recipient.phone || "", region);
+      if (!normalizedPhone) continue;
+      if (
+        !personalizationByPhone.has(normalizedPhone) &&
+        recipient.personalization
+      ) {
+        personalizationByPhone.set(normalizedPhone, recipient.personalization);
+      }
     }
 
-    if (selectedProvider === "twilio" && !TwilioProvider.isConfigured()) {
-      return c.json(
-        {
-          error:
-            "Twilio is not configured. Please configure Twilio environment variables.",
-          code: "TWILIO_NOT_CONFIGURED",
-        },
-        400,
-      );
-    }
-  }
+    const recipientRecords = uniquePhones.map((phone) => ({
+      campaign_id: campaign.id,
+      phone,
+      message: messageTemplate,
+      personalization_data: personalizationByPhone.get(phone) || null,
+      unsubscribe_short_token: getNextUnsubscribeToken(),
+      send_status: "pending" as RecipientStatus,
+    }));
 
-  const quotaCheck = await checkSmsQuota(
-    supabaseAdmin,
-    user.id,
-    uniquePhones.length,
-    userTimezone,
-  );
-  if (!quotaCheck.allowed) {
-    if (quotaCheck.checkFailed) {
+    const { error: recipientsError } = await supabaseAdmin
+      .schema("private")
+      .from("sms_campaign_recipients")
+      .insert(recipientRecords);
+
+    if (recipientsError) {
+      await supabaseAdmin
+        .schema("private")
+        .from("sms_campaigns")
+        .delete()
+        .eq("id", campaign.id);
       return c.json(
         {
-          error: `Unable to verify SMS quota right now: ${quotaCheck.error}`,
-          code: "QUOTA_CHECK_FAILED",
+          error: extractErrorMessage(recipientsError),
+          code: "RECIPIENTS_FAILED",
         },
         500,
       );
     }
 
-    return c.json(
-      {
-        error: quotaCheck.error,
-        code: "QUOTA_EXCEEDED",
-        remainingDaily: quotaCheck.remainingDaily,
-        remainingMonthly: quotaCheck.remainingMonthly,
-      },
-      403,
-    );
-  }
+    // Distribute recipients to gateways in fleet mode
+    if (isFleetMode && fleetGateways.length > 0) {
+      // Fetch the inserted recipients to get their IDs
+      const { data: insertedRecipients } = await supabaseAdmin
+        .schema("private")
+        .from("sms_campaign_recipients")
+        .select("id, phone")
+        .eq("campaign_id", campaign.id);
 
-  const { data: campaign, error: campaignError } = await supabaseAdmin
-    .schema("private")
-    .from("sms_campaigns")
-    .insert({
-      user_id: user.id,
-      sender_name: senderName,
-      provider: selectedProvider,
-      message_template: messageTemplate,
-      footer_text_template: footerTextTemplate || null,
-      use_short_links: useShortLinks || false,
-      recipient_count: uniquePhones.length,
-      status: "queued",
-      fleet_mode_enabled: isFleetMode,
-      selected_gateway_ids: isFleetMode ? selectedGatewayIds : [],
-    })
-    .select()
-    .single();
+      if (insertedRecipients) {
+        const gatewayAssignments = distributeRecipientsToGateways(
+          uniquePhones,
+          fleetGateways,
+        );
 
-  if (campaignError || !campaign) {
-    logger.error("Campaign insert failed", {
-      userId: user.id,
-      errorCode: (campaignError as Record<string, unknown>)?.code,
-      errorMessage: extractErrorMessage(campaignError),
-      fullError: JSON.stringify(campaignError),
-      insertPayload: {
-        provider: selectedProvider,
-        senderName,
-        fleetMode: isFleetMode,
-      },
+        const recipientGatewayRecords = [];
+        for (const [phone, gateway] of gatewayAssignments.entries()) {
+          const recipient = insertedRecipients.find((r) => r.phone === phone);
+          if (recipient) {
+            recipientGatewayRecords.push({
+              campaign_id: campaign.id,
+              recipient_id: recipient.id,
+              gateway_id: gateway.id,
+              gateway_name: gateway.name,
+              gateway_provider: gateway.provider,
+            });
+          }
+        }
+
+        if (recipientGatewayRecords.length > 0) {
+          const { error: assignmentError } = await supabaseAdmin
+            .schema("private")
+            .from("sms_campaign_recipient_gateways")
+            .insert(recipientGatewayRecords);
+
+          if (assignmentError) {
+            logger.error("Failed to create gateway assignments", {
+              error: assignmentError.message,
+              campaignId: campaign.id,
+            });
+          }
+        }
+      }
+    }
+
+    triggerSmsCampaignProcessorFromEdge(campaign.id).catch((error) => {
+      logger.error("Failed to trigger SMS campaign processor", {
+        error: error instanceof Error ? error.message : String(error),
+        campaignId: campaign.id,
+      });
+      // Cron remains as fallback if immediate trigger fails.
     });
-    return c.json(
-      { error: extractErrorMessage(campaignError), code: "CREATE_FAILED" },
-      500,
-    );
-  }
 
-  const usedUnsubscribeTokens = new Set<string>();
-  const getNextUnsubscribeToken = () => {
-    let token = getUniqueShortToken(10);
-    while (usedUnsubscribeTokens.has(token)) {
-      token = getUniqueShortToken(10);
-    }
-    usedUnsubscribeTokens.add(token);
-    return token;
-  };
-
-  const personalizationByPhone = new Map<string, Record<string, unknown>>();
-  for (const recipient of selectedRecipients || []) {
-    const normalizedPhone = normalizePhoneNumber(recipient.phone || "", region);
-    if (!normalizedPhone) continue;
-    if (
-      !personalizationByPhone.has(normalizedPhone) &&
-      recipient.personalization
-    ) {
-      personalizationByPhone.set(normalizedPhone, recipient.personalization);
-    }
-  }
-
-  const recipientRecords = uniquePhones.map((phone) => ({
-    campaign_id: campaign.id,
-    phone,
-    message: messageTemplate,
-    personalization_data: personalizationByPhone.get(phone) || null,
-    unsubscribe_short_token: getNextUnsubscribeToken(),
-    send_status: "pending" as RecipientStatus,
-  }));
-
-  const { error: recipientsError } = await supabaseAdmin
-    .schema("private")
-    .from("sms_campaign_recipients")
-    .insert(recipientRecords);
-
-  if (recipientsError) {
-    await supabaseAdmin
-      .schema("private")
-      .from("sms_campaigns")
-      .delete()
-      .eq("id", campaign.id);
-    return c.json(
-      {
-        error: extractErrorMessage(recipientsError),
-        code: "RECIPIENTS_FAILED",
-      },
-      500,
-    );
-  }
-
-  // Distribute recipients to gateways in fleet mode
-  if (isFleetMode && fleetGateways.length > 0) {
-    // Fetch the inserted recipients to get their IDs
-    const { data: insertedRecipients } = await supabaseAdmin
-      .schema("private")
-      .from("sms_campaign_recipients")
-      .select("id, phone")
-      .eq("campaign_id", campaign.id);
-
-    if (insertedRecipients) {
-      const gatewayAssignments = distributeRecipientsToGateways(
-        uniquePhones,
-        fleetGateways,
-      );
-
-      const recipientGatewayRecords = [];
-      for (const [phone, gateway] of gatewayAssignments.entries()) {
-        const recipient = insertedRecipients.find((r) => r.phone === phone);
-        if (recipient) {
-          recipientGatewayRecords.push({
-            campaign_id: campaign.id,
-            recipient_id: recipient.id,
-            gateway_id: gateway.id,
-            gateway_name: gateway.name,
-            gateway_provider: gateway.provider,
-          });
-        }
-      }
-
-      if (recipientGatewayRecords.length > 0) {
-        const { error: assignmentError } = await supabaseAdmin
-          .schema("private")
-          .from("sms_campaign_recipient_gateways")
-          .insert(recipientGatewayRecords);
-
-        if (assignmentError) {
-          logger.error("Failed to create gateway assignments", {
-            error: assignmentError.message,
-            campaignId: campaign.id,
-          });
-        }
-      }
-    }
-  }
-
-  triggerSmsCampaignProcessorFromEdge(campaign.id).catch((error) => {
-    logger.error("Failed to trigger SMS campaign processor", {
-      error: error instanceof Error ? error.message : String(error),
+    c.set("campaignCreate", {
       campaignId: campaign.id,
+      createdCount: uniquePhones.length,
+      userId: user.id,
     });
-    // Cron remains as fallback if immediate trigger fails.
-  });
 
-  return c.json({
-    campaignId: campaign.id,
-    recipientCount: uniquePhones.length,
-  });
-});
+    return await next();
+  },
+  createFinalResponseMiddleware,
+);
 
 // skipcq: JS-R1005 — Refactor: extract preview route into smaller helpers (provider setup, validation, message rendering)
 app.post("/campaigns/preview", authMiddleware, async (c: Context) => {

--- a/supabase/functions/sms-campaigns/middlewares-mod.ts
+++ b/supabase/functions/sms-campaigns/middlewares-mod.ts
@@ -1,0 +1,115 @@
+import { Context, Next } from "hono";
+import { createLogger } from "../_shared/logger.ts";
+import { getRegionFromTimezone } from "./utils/timezone-region.ts";
+import { isValidPhoneNumber, normalizePhoneNumber } from "./utils/phone.ts";
+
+const logger = createLogger("sms-campaigns:middleware");
+
+interface SmsPayload {
+  selectedPhones?: string[];
+  selectedRecipients?: { phone: string; personalization?: Record<string, unknown> }[];
+  timezone?: string;
+  [key: string]: unknown;
+}
+
+interface SuccessResponse {
+  campaignId: string;
+  recipientCount: number;
+}
+
+/**
+ * Derive normalized, deduplicated, valid E.164 phone numbers from a payload.
+ * Pure function so it can be unit-tested in isolation.
+ */
+export function resolveValidPhones(payload: SmsPayload): string[] {
+  const phonesFromRecipients = (payload.selectedRecipients || []).map(
+    (r) => r.phone,
+  );
+  const requestedPhones =
+    phonesFromRecipients.length > 0 ? phonesFromRecipients : payload.selectedPhones || [];
+
+  const region = getRegionFromTimezone(payload.timezone);
+  const validPhones = requestedPhones
+    .filter((phone) => isValidPhoneNumber(phone, region))
+    .map((phone) => normalizePhoneNumber(phone, region) as string);
+
+  return [...new Set(validPhones)];
+}
+
+/**
+ * Validates the SMS campaign payload (recipient presence and phone validity)
+ * and stores the filtered phone list in context. Billing-free by design —
+ * the commercial repo replaces this file to inject credit checks.
+ */
+export async function complianceMiddleware(c: Context, next: Next) {
+  if (!c.req.path.endsWith("/campaigns/create")) {
+    return next();
+  }
+
+  let payload: SmsPayload;
+  try {
+    payload = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON payload", code: "INVALID_JSON" }, 400);
+  }
+
+  const user = c.get("user");
+  if (!user?.id) {
+    return c.json({ error: "Unauthorized", code: "UNAUTHORIZED" }, 401);
+  }
+
+  const requestedPhones =
+    (payload.selectedRecipients || []).length > 0
+      ? (payload.selectedRecipients || []).map((r) => r.phone)
+      : payload.selectedPhones || [];
+
+  if (requestedPhones.length === 0) {
+    return c.json({ error: "No recipients selected", code: "NO_RECIPIENTS" }, 400);
+  }
+
+  const filteredPhones = resolveValidPhones(payload);
+
+  if (filteredPhones.length === 0) {
+    return c.json(
+      { error: "No valid phone numbers found", code: "NO_VALID_PHONES" },
+      400,
+    );
+  }
+
+  c.set("campaignCheck", {
+    filteredPhones,
+    eligibleCount: filteredPhones.length,
+    userId: user.id,
+    payload,
+  });
+
+  return await next();
+}
+
+/**
+ * Final response middleware. Returns the campaignId + recipientCount that the
+ * create handler stores in `campaignCreate` context. Commercial replaces this
+ * to append `chargedUnits`/`billingError`.
+ */
+export async function createFinalResponseMiddleware(c: Context, next: Next) {
+  if (!c.req.path.endsWith("/campaigns/create")) {
+    return next();
+  }
+
+  const campaignData = c.get("campaignCreate");
+  if (!campaignData) {
+    logger.error("No campaign data in context");
+    return c.json(
+      { error: "Campaign creation data missing", code: "INTERNAL_ERROR" },
+      500,
+    );
+  }
+
+  const { campaignId, createdCount } = campaignData;
+  const response: SuccessResponse = {
+    campaignId,
+    recipientCount: createdCount,
+  };
+
+  return c.json(response);
+}

--- a/supabase/functions/sms-campaigns/middlewares-mod.ts
+++ b/supabase/functions/sms-campaigns/middlewares-mod.ts
@@ -5,11 +5,23 @@ import { isValidPhoneNumber, normalizePhoneNumber } from "./utils/phone.ts";
 
 const logger = createLogger("sms-campaigns:middleware");
 
-interface SmsPayload {
+export interface SmsPayload {
   selectedPhones?: string[];
   selectedRecipients?: { phone: string; personalization?: Record<string, unknown> }[];
   timezone?: string;
   [key: string]: unknown;
+}
+
+/**
+ * Context shape stored under `campaignCheck` and consumed by the create
+ * route handler. The commercial override replaces this file and keeps this
+ * contract stable so the handler does not need to change.
+ */
+export interface CampaignCheckData {
+  filteredPhones: string[];
+  eligibleCount: number;
+  userId: string;
+  payload: Record<string, unknown>;
 }
 
 interface SuccessResponse {

--- a/supabase/functions/sms-campaigns/middlewares-mod.ts
+++ b/supabase/functions/sms-campaigns/middlewares-mod.ts
@@ -105,7 +105,7 @@ export async function complianceMiddleware(c: Context, next: Next) {
  */
 export async function createFinalResponseMiddleware(c: Context, next: Next) {
   if (!c.req.path.endsWith("/campaigns/create")) {
-    return next();
+    return await next();
   }
 
   const campaignData = c.get("campaignCreate");

--- a/supabase/functions/sms-campaigns/tests/middlewares-mod.test.ts
+++ b/supabase/functions/sms-campaigns/tests/middlewares-mod.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { resolveValidPhones } from "../middlewares-mod.ts";
+
+Deno.test(
+  "resolveValidPhones - dedupes and normalizes to E.164 with region",
+  () => {
+    const phones = resolveValidPhones({
+      selectedRecipients: [
+        { phone: "21697522154" },
+        { phone: "+216 97 522 154" },
+        { phone: "nope" },
+      ],
+      timezone: "Africa/Tunis",
+    });
+    assertEquals(phones, ["+21697522154"]);
+  },
+);
+
+Deno.test(
+  "resolveValidPhones - falls back to selectedPhones when no recipients",
+  () => {
+    const phones = resolveValidPhones({
+      selectedPhones: ["+33123456789", "+33123456789"],
+    });
+    assertEquals(phones, ["+33123456789"]);
+  },
+);
+
+Deno.test("resolveValidPhones - returns empty when no valid numbers", () => {
+  const phones = resolveValidPhones({ selectedPhones: ["abc", "42"] });
+  assertEquals(phones, []);
+});


### PR DESCRIPTION
SMS campaigns now support a confirmation-modal flow, architected the same way as the email-campaigns function so deploy-time feature seams can be layered in without touching open-source code.

Key changes:
- Extract `complianceMiddleware` + `createFinalResponseMiddleware` into `supabase/functions/sms-campaigns/middlewares-mod.ts` (mirrors `email-campaigns/middlewares-mod.ts`)
- Route `/campaigns/create` through `authMiddleware -> complianceMiddleware -> handler -> createFinalResponseMiddleware`
- Add `partial_two` flag to the create schema
- Show the generic confirmation dialog in the SMS composer (`SmsCampaignComposerDialog`) on 402/266 responses via `GenericComplianceDialog`, with `continue_partial` resubmit

The deploy-time feature override for `sms-campaigns/middlewares-mod.ts` ships from the separate infra repo, matching how the email-campaigns function works.

Tested: Deno middleware unit tests, Vitest composer tests, frontend lint + production build, integrated-tree `deno check`.