### PR TITLE
fix(mining): restore stepper mid-run, preserve source config, fix passive-mining visibility

### DIFF
--- a/frontend/src/components/mining/PassiveMiningDialog.vue
+++ b/frontend/src/components/mining/PassiveMiningDialog.vue
@@ -109,7 +109,11 @@ async function enablePassiveMining() {
       .from('mining_sources')
       .update({
         passive_mining: true,
-        config: draftConfig.value,
+        config: {
+          ...(miningSource.value.config ?? {}),
+          ...draftConfig.value,
+          needs_reauth: false,
+        },
       })
       .match({ email: miningSource.value.email });
 

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -633,6 +633,14 @@ async function reconnectExpiredSource(source: MiningSource) {
 onMounted(async () => {
   await $leadminer.ensureMiningSourcesLoaded();
 
+  // Refresh the active-mining state so an in-progress run shows under its
+  // source even when the app bootstrap ran before this mining started.
+  try {
+    await $leadminer.getCurrentRunningMining();
+  } catch {
+    // non-blocking: sources list still renders without mining state
+  }
+
   const reconnectEmail = $route.query.reconnect as string;
 
   if (reconnectEmail) {

--- a/frontend/src/pages/sources.vue
+++ b/frontend/src/pages/sources.vue
@@ -494,7 +494,12 @@ async function confirmDelete() {
 
 async function togglePassiveMining(source: MiningSource, value: boolean) {
   try {
-    await updatePassiveMining(source.email, source.type, value);
+    await updatePassiveMining(
+      source.email,
+      source.type,
+      value,
+      source.config ?? {},
+    );
   } catch (error) {
     source.passive_mining = !value;
     $toast.add({

--- a/frontend/src/stores/leadminer.ts
+++ b/frontend/src/stores/leadminer.ts
@@ -716,8 +716,8 @@ export const useLeadminerStore = defineStore('leadminer', () => {
 
       const hasRequiredPhases =
         mType === MiningTypes.FILE
-          ? Boolean(extract) && Boolean(clean)
-          : Boolean(fetch) && Boolean(extract) && Boolean(clean);
+          ? Boolean(extract)
+          : Boolean(fetch) && Boolean(extract);
 
       if (!hasRequiredPhases) return 1;
 

--- a/frontend/src/utils/sources.ts
+++ b/frontend/src/utils/sources.ts
@@ -121,12 +121,22 @@ export async function updatePassiveMining(
   email: string,
   type: string,
   value: boolean,
+  existingConfig: Record<string, unknown> = {},
 ): Promise<void> {
+  const update: Record<string, unknown> = { passive_mining: value };
+
+  // When enabling continuous extraction, clear a stale needs_reauth flag and
+  // preserve any existing config keys (errors/status/last_run) instead of
+  // letting passive-mining exclude the source.
+  if (value) {
+    update.config = { ...existingConfig, needs_reauth: false };
+  }
+
   const { error } = await useSupabaseClient()
     // @ts-expect-error: Issue with nuxt/supabase
     .schema('private')
     .from('mining_sources')
-    .update({ passive_mining: value })
+    .update(update)
     .eq('email', email)
     .eq('type', type);
 

--- a/supabase/functions/passive-mining/index.ts
+++ b/supabase/functions/passive-mining/index.ts
@@ -127,7 +127,11 @@ async function getMiningSources() {
     .from("mining_sources")
     .select("id, email, user_id, config")
     .match({ passive_mining: true })
-    .not("config->>needs_reauth", "eq", "true");
+    // Keep sources unless needs_reauth is EXACTLY "true". A missing key or
+    // "false" must NOT exclude the source — PostgREST `not.eq` on a jsonb key
+    // that is absent evaluates to NULL and incorrectly drops the row, which
+    // made the cron report "Found 0 mining sources" after a config rewrite.
+    .or("config->>needs_reauth.is.null,config->>needs_reauth.neq.true");
 
   if (error) {
     console.error("Error fetching mining sources:", error.message);


### PR DESCRIPTION
## Summary

Fixes four mining bugs around stepper restoration, source-config preservation, and passive-mining visibility.

- **Stepper not restored on /mine reload mid-mining** — `getCurrentRunningMining()` required the `clean` phase which is legitimately `null` during fetch/extract. Relaxed to require only `fetch && extract`.
- **Active mining not shown under source on /sources** — `/sources` never refreshed active-mining state on mount; now calls `getCurrentRunningMining()`.
- **`enablePassiveMining()` wiped source config** — replaced whole config (dropping `errors`/`status`/`last_run`/`needs_reauth`); now merges + clears `needs_reauth`.
- **Passive-mining "Found 0 sources"** — PostgREST `.not(config->>needs_reauth, eq, true)` drops rows where the key is absent (NULL). Switched to `.or(is.null, neq.true)`; `updatePassiveMining` preserves config and clears `needs_reauth` on enable.

## Verification
- SQL-verified old-vs-new filter behavior (absent `needs_reauth` key)
- Vitest: 18/20 (2 pre-existing failures unrelated)
- ESLint 0 errors, prettier clean, deno check pass

Fixes mining stepper restore + passive-mining visibility.
