### PR TITLE
fix(auth): post-login 'Loading...' freeze — non-blocking mining resume

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -156,13 +156,24 @@ watch(activeTask, () => {
   reset();
 });
 
+// Resume an in-progress mining run / restore the stepper after the app has
+// mounted. Keeping this out of the root component's async setup prevents a
+// post-login SPA navigation from freezing the whole app on the network round
+// trip (the layout would otherwise stay stuck on the "Loading..." loader).
 if ($user.value) {
-  $stepper.isInitializing = true;
-  await $leadminerStore.ensureMiningSourcesLoaded();
-  const step = await $leadminerStore.getCurrentRunningMining();
-  if (step !== undefined) {
-    $stepper.index = step;
-  }
-  $stepper.isInitializing = false;
+  onMounted(async () => {
+    $stepper.isInitializing = true;
+    try {
+      await $leadminerStore.ensureMiningSourcesLoaded();
+      const step = await $leadminerStore.getCurrentRunningMining();
+      if (step !== undefined) {
+        $stepper.index = step;
+      }
+    } catch (error) {
+      console.error('[app] failed to resume mining state', error);
+    } finally {
+      $stepper.isInitializing = false;
+    }
+  });
 }
 </script>

--- a/frontend/src/components/mining/PassiveMiningDialog.vue
+++ b/frontend/src/components/mining/PassiveMiningDialog.vue
@@ -113,6 +113,8 @@ async function enablePassiveMining() {
           ...(miningSource.value.config ?? {}),
           ...draftConfig.value,
           needs_reauth: false,
+          status: miningSource.value.config?.status ?? 'idle',
+          last_run: miningSource.value.config?.last_run ?? null,
         },
       })
       .match({ email: miningSource.value.email });

--- a/frontend/src/utils/sources.ts
+++ b/frontend/src/utils/sources.ts
@@ -125,11 +125,18 @@ export async function updatePassiveMining(
 ): Promise<void> {
   const update: Record<string, unknown> = { passive_mining: value };
 
-  // When enabling continuous extraction, clear a stale needs_reauth flag and
-  // preserve any existing config keys (errors/status/last_run) instead of
-  // letting passive-mining exclude the source.
+  // When enabling continuous extraction, clear a stale needs_reauth flag,
+  // preserve any existing config keys (errors/status/last_run) and seed the
+  // passive mining state so the /sources UI shows a status immediately —
+  // otherwise the config stays as a bare { needs_reauth:false } with no
+  // passive-mining tracking fields.
   if (value) {
-    update.config = { ...existingConfig, needs_reauth: false };
+    update.config = {
+      ...existingConfig,
+      needs_reauth: false,
+      status: existingConfig.status ?? 'idle',
+      last_run: existingConfig.last_run ?? null,
+    };
   }
 
   const { error } = await useSupabaseClient()


### PR DESCRIPTION
## Summary

Two fixes:

1. **Post-login "Loading..." freeze** — `app.vue` awaited the mining-source/resume in the root component setup. A SPA navigation right after login raced that await and never mounted the app → permanent "Loading..." loader with no content (router updated, DOM frozen). Moved resume into `onMounted` (non-blocking). Reproduced via agent-browser: login now lands on `/mine` with full header.

2. **Passive-mining status missing on /sources** — enabling continuous extraction wrote only `{ needs_reauth:false, ...config }`, so config carried no tracking fields and /sources showed no passive status until a cron run. Now seeds `status:'idle'` + `last_run:null` on enable (preserving existing values); `updatePassiveMining` and the dialog both updated.
