### PR TITLE
fix(auth): hard-reload after email/password login to break 'Loading...' loop

### DIFF
--- a/frontend/src/components/auth/EmailAuth.vue
+++ b/frontend/src/components/auth/EmailAuth.vue
@@ -245,6 +245,7 @@ import {
   isInvalidPassword as isInvalidPasswordSyntax,
 } from '@/utils/password';
 import { AuthApiError, AuthWeakPasswordError } from '@supabase/supabase-js';
+import { reloadNuxtApp } from '#app';
 import type { ToastMessageOptions } from 'primevue/toast';
 import { useI18n } from 'vue-i18n';
 
@@ -324,7 +325,16 @@ async function signInWithEmailAndPassword() {
     if (error) {
       throw error;
     }
-    await navigateTo({ path: '/' });
+    // Hard-reload instead of an SPA push: right after signInWithPassword the
+    // supabase cookie-write plugin and PKCE session detection are mid-flight,
+    // which can leave the Nuxt router frozen on the login route (URL shows the
+    // target path but the layout/page never re-render → permanent "Loading...").
+    // A fresh SSR+hydrate load of the target route is the reliable path.
+    reloadNuxtApp({
+      path: '/',
+      persistState: false,
+      fresh: true,
+    });
   } catch (error) {
     if (error instanceof Error) {
       setInvalidInputs(true);


### PR DESCRIPTION
## Summary

Fixes the post-login **"Loading..." loop** that persists even with the earlier `onMounted` change.

**Root cause (reproduced with agent-browser):** after `signInWithPassword`, `navigateTo('/')` (SPA push) races the supabase **cookie-write plugin** (async chunked-cookie writes) and **PKCE `detectSessionInUrl`**. This can leave the Nuxt router **frozen**: `location.href` shows the target path (`/mine`) but `router.currentRoute` stays on the login route, the layout never re-renders past the post-login loader, and subsequent `router.push()` calls stop working — a permanent "Loading..." screen.

**Fix:** after password login, reload the app (`reloadNuxtApp` with `fresh:true`) instead of SPA `navigateTo`, so the target route is served via fresh SSR+hydrate — the path that provably works.

**Verified with agent-browser:** login now lands on `/mine` with the full header and the mining stepper renders.

One file: `frontend/src/components/auth/EmailAuth.vue`.
