### PR TITLE
fix: refine contacts cumulative stats + /contacts realtime INSERT gating + refine timeout

### DIFF
--- a/backend/src/db/mail.ts
+++ b/backend/src/db/mail.ts
@@ -1,4 +1,8 @@
 import supabaseClient from '../utils/supabase';
+import logger from '../utils/logger';
+
+// Fail with a clear error before Kong's ~60s upstream read timeout.
+const REFINE_CONTACTS_TIMEOUT_MS = 55_000;
 
 export async function mailMiningComplete(miningId: string) {
   const { error } = await supabaseClient.functions.invoke(
@@ -17,11 +21,37 @@ export async function mailMiningComplete(miningId: string) {
 }
 
 /**
- * Refines contacts in database.
+ * Refine a user's contacts, racing a timeout so failures surface before Kong's
+ * ~60s upstream read timeout (instead of a generic gateway error).
  */
 export async function refineContacts(userId: string) {
-  const { error } = await supabaseClient
+  const refine = supabaseClient
     .schema('private')
-    .rpc('refine_persons', { p_user_id: userId });
-  if (error) throw error;
+    .rpc('refine_persons', { p_user_id: userId })
+    .then(({ error }) => {
+      if (error) throw error;
+    });
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Refine contacts for user ${userId} timed out after ${REFINE_CONTACTS_TIMEOUT_MS}ms`
+        )
+      );
+    }, REFINE_CONTACTS_TIMEOUT_MS);
+  });
+
+  try {
+    await Promise.race([refine, timeout]);
+  } catch (error) {
+    logger.error('Failed to refine contacts', {
+      userId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    throw error;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/backend/src/db/pg/PgContacts.ts
+++ b/backend/src/db/pg/PgContacts.ts
@@ -116,6 +116,23 @@ export default class PgContacts implements Contacts {
     telephone = EXCLUDED.telephone,
     alternate_name = ARRAY(SELECT DISTINCT UNNEST(COALESCE(private.persons.alternate_name, '{}') || EXCLUDED.alternate_name)),
     alternate_email = ARRAY(SELECT DISTINCT UNNEST(COALESCE(private.persons.alternate_email, '{}') || EXCLUDED.alternate_email))
+  WHERE
+    private.persons.name IS DISTINCT FROM EXCLUDED.name
+    OR private.persons.url IS DISTINCT FROM EXCLUDED.url
+    OR private.persons.image IS DISTINCT FROM EXCLUDED.image
+    OR private.persons.location IS DISTINCT FROM EXCLUDED.location
+    OR private.persons.same_as IS DISTINCT FROM EXCLUDED.same_as
+    OR private.persons.given_name IS DISTINCT FROM EXCLUDED.given_name
+    OR private.persons.family_name IS DISTINCT FROM EXCLUDED.family_name
+    OR private.persons.job_title IS DISTINCT FROM EXCLUDED.job_title
+    OR private.persons.identifiers IS DISTINCT FROM EXCLUDED.identifiers
+    OR private.persons.works_for IS DISTINCT FROM EXCLUDED.works_for
+    OR private.persons.mining_id IS DISTINCT FROM EXCLUDED.mining_id
+    OR private.persons.telephone IS DISTINCT FROM EXCLUDED.telephone
+    OR private.persons.alternate_name IS DISTINCT FROM
+        ARRAY(SELECT DISTINCT UNNEST(COALESCE(private.persons.alternate_name, '{}') || EXCLUDED.alternate_name))
+    OR private.persons.alternate_email IS DISTINCT FROM
+        ARRAY(SELECT DISTINCT UNNEST(COALESCE(private.persons.alternate_email, '{}') || EXCLUDED.alternate_email))
   RETURNING persons.id, persons.email
 )
 SELECT p.id, p.email FROM upserted p
@@ -186,7 +203,8 @@ LIMIT 1;
 
   private static readonly INSERT_POC_BULK_SQL = `
     INSERT INTO private.pointsofcontact("message_id","name","from","reply_to","to","cc","bcc","body","person_id","plus_address", "user_id")
-    VALUES %L;`;
+    VALUES %L
+    ON CONFLICT (user_id, message_id, person_id) DO NOTHING;`;
 
   private static readonly SELECT_RECENT_EMAIL_STATUS_BY_EMAIL = `
     SELECT *

--- a/backend/src/services/tasks-manager-v2/Pipeline.ts
+++ b/backend/src/services/tasks-manager-v2/Pipeline.ts
@@ -224,10 +224,13 @@ export class Pipeline {
         await mailMiningComplete(this.miningId);
       }
     } catch (err) {
-      logger.error(
-        'Failed to trigger email notification, refine contacts',
-        err
-      );
+      // Refine (or the completion email) failed after mining completed. The
+      // email reads refined stats, so a failure here leaves them stale.
+      logger.error('Refine contacts / completion email failed', {
+        miningId: this.miningId,
+        userId: this.userId,
+        error: (err as Error).message
+      });
     } finally {
       const eventName = this.failed ? 'mining-failed' : 'mining-completed';
       this.progressHandlerSSE.sendSSE(eventName, eventName);

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -12,6 +12,7 @@ import {
 import { convertDates } from '~/utils/contacts';
 import {
   applyReconciledContacts,
+  buildPersonChangeFilters,
   collectRealtimePersonIds,
   getContactKey,
   resolveRealtimeAction,
@@ -271,6 +272,79 @@ export const useContactsStore = defineStore('contacts-store', () => {
   }
 
   /**
+   * Handle one person realtime event. UPDATE + DELETE always apply; INSERT
+   * arrives only while a foreground mining runs (see syncRealtimeInsertListener).
+   */
+  function handlePersonRealtimeEvent(
+    payload: RealtimePostgresChangesPayload<RealtimePersonRow>,
+  ) {
+    if (!getCurrentUserId()) return;
+
+    const action = resolveRealtimeAction(payload, {
+      activeMining: $leadminerStore.activeMiningTask,
+    });
+
+    switch (action.kind) {
+      case 'stream':
+        updateContactsCache(action.row as unknown as Contact);
+        updateContactList.value = true;
+        return;
+      case 'remove':
+        removeOldContacts([action.id]);
+        updateContactList.value = true;
+        return;
+      case 'reconcile':
+        for (const id of action.personIds) {
+          pendingReconcilePersonIds.add(id);
+        }
+        scheduleReconcile();
+        return;
+      case 'none':
+        return;
+      default:
+        return;
+    }
+  }
+
+  /**
+   * Build the contacts channel for a user. Filters are fixed at subscribe time,
+   * so the INSERT listener is included only when a mining is active.
+   */
+  function createContactsRealtimeChannel(userId: string) {
+    const channel = $supabase.channel(`contacts-table-${userId}`);
+
+    channel.on('system', { event: 'reconnected' }, () => {
+      console.debug('Realtime reconnected — reloading contacts');
+      pendingReconcilePersonIds.clear();
+      reloadContacts();
+    });
+
+    for (const filter of buildPersonChangeFilters(
+      userId,
+      $leadminerStore.activeMiningTask,
+    )) {
+      channel.on('postgres_changes', filter, handlePersonRealtimeEvent);
+    }
+
+    return channel;
+  }
+
+  /**
+   * Rebuild the channel when mining state flips, to toggle the INSERT
+   * listener at the server side.
+   */
+  function syncRealtimeInsertListener() {
+    if (!realtimeChannel || !realtimeChannelUserId) return;
+    const userId = realtimeChannelUserId;
+
+    $supabase.removeChannel(realtimeChannel);
+    realtimeChannel = null;
+
+    realtimeChannel = createContactsRealtimeChannel(userId);
+    realtimeChannel.subscribe();
+  }
+
+  /**
    * Subscribes to real-time updates for contacts.
    */
   function subscribeToRealtimeUpdates() {
@@ -285,51 +359,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
 
     if (realtimeChannel) return;
 
-    realtimeChannel = $supabase.channel(`contacts-table-${userId}`);
-
-    realtimeChannel.on('system', { event: 'reconnected' }, () => {
-      console.debug('Realtime reconnected — reloading contacts');
-      pendingReconcilePersonIds.clear();
-      reloadContacts();
-    });
-
-    realtimeChannel.on(
-      'postgres_changes',
-      {
-        event: '*',
-        schema: 'private',
-        table: 'persons',
-        filter: `user_id=eq.${userId}`,
-      },
-      (payload: RealtimePostgresChangesPayload<RealtimePersonRow>) => {
-        if (!getCurrentUserId()) return;
-
-        const action = resolveRealtimeAction(payload, {
-          activeMining: $leadminerStore.activeMiningTask,
-        });
-
-        switch (action.kind) {
-          case 'stream':
-            updateContactsCache(action.row as unknown as Contact);
-            updateContactList.value = true;
-            return;
-          case 'remove':
-            removeOldContacts([action.id]);
-            updateContactList.value = true;
-            return;
-          case 'reconcile':
-            for (const id of action.personIds) {
-              pendingReconcilePersonIds.add(id);
-            }
-            scheduleReconcile();
-            return;
-          case 'none':
-            return;
-          default:
-            return;
-        }
-      },
-    );
+    realtimeChannel = createContactsRealtimeChannel(userId);
     realtimeChannelUserId = userId;
     startSyncInterval();
     realtimeChannel.subscribe();
@@ -468,6 +498,15 @@ export const useContactsStore = defineStore('contacts-store', () => {
     { deep: true },
   );
 
+  watch(
+    () => $leadminerStore.activeMiningTask,
+    () => {
+      // Flip the server-side postgres_changes filter between UPDATE+DELETE-only
+      // and +INSERT when a foreground mining starts/stops.
+      syncRealtimeInsertListener();
+    },
+  );
+
   const combinedLocations = computed(() => {
     return contactsList.value
       ?.filter(
@@ -511,6 +550,7 @@ export const useContactsStore = defineStore('contacts-store', () => {
     refineContacts,
     subscribeToRealtimeUpdates,
     unsubscribeFromRealtimeUpdates,
+    syncRealtimeInsertListener,
     startSyncInterval,
     clearSyncInterval,
     removeOldContacts,

--- a/frontend/src/tests/unit/contacts-realtime.test.ts
+++ b/frontend/src/tests/unit/contacts-realtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildPersonChangeFilters,
   applyReconciledContacts,
   collectRealtimePersonIds,
   getContactKey,
@@ -171,5 +172,23 @@ describe('resolveRealtimeAction', () => {
       { activeMining: false },
     );
     expect(action).toEqual({ kind: 'reconcile', personIds: ['p1'] });
+  });
+});
+
+describe('buildPersonChangeFilters', () => {
+  it('always includes UPDATE + DELETE and excludes INSERT when not mining', () => {
+    const filters = buildPersonChangeFilters('u1', false);
+    expect(filters).toHaveLength(2);
+    expect(filters.map((f) => f.event).sort()).toEqual(['DELETE', 'UPDATE']);
+    expect(filters.every((f) => f.filter === 'user_id=eq.u1')).toBe(true);
+  });
+
+  it('adds the INSERT filter while a foreground mining is active', () => {
+    const filters = buildPersonChangeFilters('u1', true);
+    expect(filters.map((f) => f.event).sort()).toEqual([
+      'DELETE',
+      'INSERT',
+      'UPDATE',
+    ]);
   });
 });

--- a/frontend/src/utils/contacts-realtime.ts
+++ b/frontend/src/utils/contacts-realtime.ts
@@ -104,6 +104,35 @@ export type RealtimeAction =
   | { kind: 'reconcile'; personIds: string[] }
   | { kind: 'none' };
 
+export type PersonChangeFilter = {
+  event: 'INSERT' | 'UPDATE' | 'DELETE';
+  schema: 'private';
+  table: 'persons';
+  filter: string;
+};
+
+/**
+ * Filters for the contacts realtime channel. UPDATE + DELETE are always
+ * subscribed; INSERT only while a foreground mining is streaming new contacts,
+ * so background mining never floods the client (new rows appear on reload).
+ */
+export function buildPersonChangeFilters(
+  userId: string,
+  includeInsert: boolean,
+): PersonChangeFilter[] {
+  const base = {
+    schema: 'private' as const,
+    table: 'persons' as const,
+    filter: `user_id=eq.${userId}`,
+  };
+  const filters: PersonChangeFilter[] = [
+    { ...base, event: 'UPDATE' },
+    { ...base, event: 'DELETE' },
+  ];
+  if (includeInsert) filters.push({ ...base, event: 'INSERT' });
+  return filters;
+}
+
 export function resolveRealtimeAction(
   payload: {
     eventType: 'INSERT' | 'UPDATE' | 'DELETE';

--- a/supabase/migrations/20260904000000_refine_persons_ledger_accumulate.sql
+++ b/supabase/migrations/20260904000000_refine_persons_ledger_accumulate.sql
@@ -1,0 +1,348 @@
+-- ============================================================================
+-- refine_persons: cumulative stats via a messages ledger + transient POC
+-- ============================================================================
+-- Problems fixed:
+--   1. Slow: pointsofcontact had no (user_id, ...) index -> full table scan ->
+--      Kong ~60s upstream timeout on refine.
+--   2. Wrong stats: pointsofcontact grew unbounded and refinedpersons was
+--      overwritten each run, so it only reflected the last mining cycle.
+--
+-- New model:
+--   - messages: permanent per-user ledger with a refined_at marker (never
+--     drained, never re-counted). Inserts stay idempotent.
+--   - pointsofcontact: transient staging, purged once its messages are refined.
+--   - refinedpersons: cumulative via an accumulate upsert (counts += delta,
+--     recency/seniority GREATEST/LEAST, tags distinct union).
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. pointsofcontact indexes (created on each HASH(user_id) partition)
+-- ---------------------------------------------------------------------------
+
+-- Support refine's join and person scoping.
+CREATE INDEX IF NOT EXISTS pointsofcontact_user_message_idx
+    ON private.pointsofcontact (user_id, message_id);
+CREATE INDEX IF NOT EXISTS pointsofcontact_user_person_idx
+    ON private.pointsofcontact (user_id, person_id);
+
+-- Purge POC rows whose message no longer exists. These were already counted by
+-- the old drain-based refine, so dropping them loses no statistics.
+DO $$
+DECLARE
+    v_batch bigint := 100000;
+    v_deleted bigint;
+    v_total bigint := 0;
+BEGIN
+    LOOP
+        WITH orphans AS (
+            SELECT poc.ctid
+            FROM private.pointsofcontact poc
+            WHERE NOT EXISTS (
+                SELECT 1 FROM private.messages m
+                WHERE m.message_id = poc.message_id AND m.user_id = poc.user_id
+            )
+            LIMIT v_batch
+            FOR UPDATE
+        )
+        DELETE FROM private.pointsofcontact poc
+        USING orphans o
+        WHERE poc.ctid = o.ctid;
+        GET DIAGNOSTICS v_deleted := ROW_COUNT;
+        v_total := v_total + v_deleted;
+        EXIT WHEN v_deleted < v_batch;
+    END LOOP;
+    RAISE NOTICE 'refine migration: purged % orphan pointsofcontact rows', v_total;
+END $$;
+
+-- Deduplicate remaining rows from re-mined folders before the unique index.
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY user_id, message_id, person_id ORDER BY id) AS rn
+    FROM private.pointsofcontact
+)
+DELETE FROM private.pointsofcontact d
+USING ranked r
+WHERE d.id = r.id AND r.rn > 1;
+
+-- Backs the backend's idempotent POC inserts.
+CREATE UNIQUE INDEX IF NOT EXISTS pointsofcontact_user_message_person_uq
+    ON private.pointsofcontact (user_id, message_id, person_id);
+
+-- Supports the tags aggregation.
+CREATE INDEX IF NOT EXISTS tags_user_person_idx
+    ON private.tags (user_id, person_id);
+
+-- Key join index for refine's hot path (POC join messages). The (message_id,
+-- user_id) PK is unusable after HASH(user_id) partition pruning, so index
+-- messages by user_id first to avoid a nested-loop seq scan.
+CREATE INDEX IF NOT EXISTS messages_user_message_idx
+    ON private.messages (user_id, message_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. messages ledger: add refined_at marker (propagates to partitions)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE private.messages ADD COLUMN IF NOT EXISTS refined_at timestamptz;
+CREATE INDEX IF NOT EXISTS messages_user_refined_at_idx
+    ON private.messages (user_id, refined_at);
+
+-- ---------------------------------------------------------------------------
+-- 3. refine_persons: ledger + transient POC + accumulate
+-- ---------------------------------------------------------------------------
+
+-- Compute temperature only when not supplied, so refine can precompute it
+-- inline and skip the per-row cost. Inserts without a temperature (backend)
+-- still get it computed here as before.
+CREATE OR REPLACE FUNCTION private.trg_set_contact_temperature()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+BEGIN
+  IF NEW.temperature IS NULL THEN
+    NEW.temperature := private.contact_temperature(
+      NEW.sender,
+      NEW.recipient,
+      NEW.conversations,
+      NEW.replied_conversations,
+      NEW.recency,
+      NEW.seniority,
+      now()
+    );
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP FUNCTION IF EXISTS private.refine_persons(uuid);
+DROP FUNCTION IF EXISTS private.refine_persons(uuid, uuid[]);
+
+CREATE FUNCTION private.refine_persons(p_user_id uuid, p_person_ids uuid[] DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+    v_scope uuid[];
+    v_is_scoped boolean := p_person_ids IS NOT NULL AND cardinality(p_person_ids) > 0;
+BEGIN
+    -- NULL = whole-user backfill; ids = only those persons' unrefined messages.
+    -- Callers always pass a message's full person set, so shared messages are
+    -- refined for every touched person in one pass.
+    IF v_is_scoped THEN
+        v_scope := p_person_ids;
+        DROP TABLE IF EXISTS tmp_scope;
+        CREATE TEMP TABLE tmp_scope ON COMMIT DROP AS
+            SELECT unnest(v_scope) AS person_id;
+    END IF;
+
+    -- Stage each unrefined message's POC rows (optionally scoped to persons).
+    IF v_is_scoped THEN
+        CREATE TEMP TABLE user_points_of_contact ON COMMIT DROP AS
+            SELECT
+                poc.person_id,
+                poc.name,
+                poc.plus_address,
+                poc.message_id,
+                poc."from",
+                poc."to",
+                poc.bcc,
+                poc.cc,
+                poc.reply_to,
+                m.date,
+                m.conversation
+            FROM private.pointsofcontact poc
+            JOIN private.messages m
+                ON poc.message_id = m.message_id AND poc.user_id = m.user_id
+            JOIN tmp_scope sc ON sc.person_id = poc.person_id
+            WHERE poc.user_id = p_user_id
+              AND m.refined_at IS NULL;
+    ELSE
+        CREATE TEMP TABLE user_points_of_contact ON COMMIT DROP AS
+            SELECT
+                poc.person_id,
+                poc.name,
+                poc.plus_address,
+                poc.message_id,
+                poc."from",
+                poc."to",
+                poc.bcc,
+                poc.cc,
+                poc.reply_to,
+                m.date,
+                m.conversation
+            FROM private.pointsofcontact poc
+            JOIN private.messages m
+                ON poc.message_id = m.message_id AND poc.user_id = m.user_id
+            WHERE poc.user_id = p_user_id
+              AND m.refined_at IS NULL;
+    END IF;
+
+    CREATE TEMP TABLE grouped_tags ON COMMIT DROP AS
+        SELECT
+            t.person_id,
+            array_agg(t.name) AS tags
+        FROM private.tags t
+        WHERE t.user_id = p_user_id
+          AND t.person_id IN (SELECT person_id FROM user_points_of_contact)
+        GROUP BY t.person_id
+        HAVING
+            BOOL_OR(t.source = 'refined#email_address' AND t.reachable = 1)
+            AND (
+                NOT BOOL_OR(t.source = 'refined#message_header')
+                OR BOOL_OR(t.source = 'refined#message_header' AND t.reachable != 3)
+            );
+
+    CREATE TEMP TABLE name_aggregates ON COMMIT DROP AS
+        SELECT
+            upc.person_id,
+            upc.name,
+            MAX(upc.date) AS recent_date,
+            COUNT(*) AS total,
+            array_agg(upc.name) OVER (PARTITION BY upc.person_id) AS alternate_name
+        FROM user_points_of_contact upc
+        WHERE upc.name IS NOT NULL
+        GROUP BY upc.person_id, upc.name;
+
+    CREATE TEMP TABLE real_names ON COMMIT DROP AS
+        SELECT DISTINCT
+            na.person_id,
+            FIRST_VALUE(na.name) OVER (
+                PARTITION BY na.person_id
+                ORDER BY na.total DESC, na.recent_date DESC
+            ) AS preferred_name,
+            na.alternate_name
+        FROM name_aggregates na;
+
+    CREATE TEMP TABLE email_aggregates ON COMMIT DROP AS
+        SELECT
+            upc.person_id,
+            MAX(upc.date) AS recency,
+            MIN(upc.date) AS seniority,
+            private.get_distinct_or_exclude_from_array(
+                array_agg(upc.plus_address)::text[],
+                ARRAY[]::text[]
+            ) AS alternate_email,
+            COUNT(*) AS occurrence,
+            COUNT(CASE WHEN upc."from" = true OR upc.reply_to = true THEN 1 END) AS sender,
+            COUNT(CASE WHEN upc."to" = true OR upc.bcc = true OR upc.cc = true THEN 1 END) AS recipient,
+            COUNT(CASE WHEN upc.conversation = true THEN 1 END) AS conversations,
+            COUNT(CASE WHEN upc.conversation = true AND upc."from" = true THEN 1 END) AS replied_conversations
+        FROM user_points_of_contact upc
+        GROUP BY upc.person_id;
+
+    CREATE TEMP TABLE combined_data ON COMMIT DROP AS
+        SELECT
+            ea.person_id,
+            ea.recency,
+            ea.seniority,
+            ea.occurrence,
+            ea.sender,
+            ea.recipient,
+            ea.conversations,
+            ea.replied_conversations,
+            ea.alternate_email,
+            gt.tags AS tags,
+            pn.preferred_name AS name,
+            private.get_distinct_or_exclude_from_array(
+                pn.alternate_name,
+                ARRAY[pn.preferred_name]
+            ) AS alternate_name
+        FROM email_aggregates ea
+        LEFT JOIN real_names pn ON ea.person_id = pn.person_id
+        JOIN grouped_tags gt ON ea.person_id = gt.person_id;
+
+    -- Refresh person identity, skipping unchanged rows to avoid redundant updates
+    -- (and their realtime events).
+    UPDATE private.persons p
+    SET
+        name = cd.name,
+        alternate_name = cd.alternate_name,
+        alternate_email = cd.alternate_email
+    FROM combined_data cd
+    WHERE p.id = cd.person_id
+      AND p.user_id = p_user_id
+      AND (
+        p.name IS DISTINCT FROM cd.name
+        OR p.alternate_name IS DISTINCT FROM cd.alternate_name
+        OR p.alternate_email IS DISTINCT FROM cd.alternate_email
+      );
+
+    -- Accumulate into refinedpersons (never overwrite). Temperature is computed
+    -- inline on both branches so the per-row trigger does not recompute it.
+    INSERT INTO private.refinedpersons (
+        person_id, user_id, occurrence, recency, seniority,
+        sender, recipient, conversations, replied_conversations, tags, temperature
+    )
+    SELECT
+        cd.person_id,
+        p_user_id,
+        cd.occurrence,
+        cd.recency,
+        cd.seniority,
+        cd.sender,
+        cd.recipient,
+        cd.conversations,
+        cd.replied_conversations,
+        cd.tags,
+        private.contact_temperature(
+            cd.sender::integer, cd.recipient::integer, cd.conversations::integer,
+            cd.replied_conversations::integer, cd.recency, cd.seniority, now()
+        )
+    FROM combined_data cd
+    ON CONFLICT (person_id, user_id) DO UPDATE
+    SET
+        occurrence = COALESCE(private.refinedpersons.occurrence, 0) + EXCLUDED.occurrence,
+        recency    = GREATEST(private.refinedpersons.recency, EXCLUDED.recency),
+        seniority  = LEAST(private.refinedpersons.seniority, EXCLUDED.seniority),
+        sender     = COALESCE(private.refinedpersons.sender, 0) + EXCLUDED.sender,
+        recipient  = COALESCE(private.refinedpersons.recipient, 0) + EXCLUDED.recipient,
+        conversations = COALESCE(private.refinedpersons.conversations, 0) + EXCLUDED.conversations,
+        replied_conversations = COALESCE(private.refinedpersons.replied_conversations, 0) + EXCLUDED.replied_conversations,
+        tags = ARRAY(
+            SELECT DISTINCT unnest(
+                COALESCE(private.refinedpersons.tags, '{}'::text[]) ||
+                COALESCE(EXCLUDED.tags, '{}'::text[])
+            )
+        ),
+        temperature = private.contact_temperature(
+            (COALESCE(private.refinedpersons.sender, 0) + EXCLUDED.sender)::integer,
+            (COALESCE(private.refinedpersons.recipient, 0) + EXCLUDED.recipient)::integer,
+            (COALESCE(private.refinedpersons.conversations, 0) + EXCLUDED.conversations)::integer,
+            (COALESCE(private.refinedpersons.replied_conversations, 0) + EXCLUDED.replied_conversations)::integer,
+            GREATEST(private.refinedpersons.recency, EXCLUDED.recency),
+            LEAST(private.refinedpersons.seniority, EXCLUDED.seniority),
+            now()
+        ),
+        updated_at = now();
+
+    -- Flag processed messages so they are never re-counted.
+    UPDATE private.messages m
+    SET refined_at = now()
+    FROM (SELECT DISTINCT message_id FROM user_points_of_contact) t
+    WHERE m.user_id = p_user_id
+      AND m.refined_at IS NULL
+      AND m.message_id = t.message_id;
+
+    -- Drop the processed POC rows (transient staging).
+    DELETE FROM private.pointsofcontact poc
+    USING (SELECT DISTINCT message_id FROM user_points_of_contact) t
+    WHERE poc.user_id = p_user_id
+      AND poc.message_id = t.message_id;
+
+    DROP TABLE IF EXISTS user_points_of_contact;
+    DROP TABLE IF EXISTS tmp_scope;
+    DROP TABLE IF EXISTS grouped_tags;
+    DROP TABLE IF EXISTS name_aggregates;
+    DROP TABLE IF EXISTS real_names;
+    DROP TABLE IF EXISTS email_aggregates;
+    DROP TABLE IF EXISTS combined_data;
+END;
+$$;
+COMMIT;
+
+-- After deploying: run one full refine per active user so any residual
+-- unrefined messages are accounted for:
+--   SELECT private.refine_persons('<user_id>');


### PR DESCRIPTION
## Summary

Fixes two bugs from the client demo against QA:

1. **`refine contacts` SQL timed out** — `refine_persons` scanned the whole (growing) `pointsofcontact` table with no `(user_id, ...)` index, blew Kong's ~60s upstream timeout, and only reflected the *last* mining cycle.
2. **`MessagePerSecondRateLimitReached` + mining contacts streaming into /contacts mid-session** — the contacts page subscribed to all person changes, so background mining flooded the client and the realtime tenant (which also starved the credits-profile channel).

## Key changes

### refine_persons rewrite (SQL, backend)
- `messages` becomes a permanent per-user **ledger** (`refined_at` marker) — never drained, never re-counted; `pointsofcontact` becomes **transient** staging (purged after refine) with idempotent inserts (`ON CONFLICT ... DO NOTHING`).
- `refinedpersons` now **accumulates** (counts `+= delta`, recency/seniority `GREATEST/LEAST`, tags distinct-union; temperature computed inline matching the trigger). Stats are cumulative, no more double-counting.
- Partition-aware indexes on `pointsofcontact (user_id, message_id)`, `(user_id, person_id)`, and `messages (user_id, message_id)` — the POC join drops the nested-loop seq scan; one-time purge of ~2.5M orphaned POC rows.
- Backend writes: idempotent POC bulk insert, `IS DISTINCT FROM` change-guard on the single-row person upsert, and a 55s refine timeout with clear logging (refine stays awaited — the mining-complete email reads refined stats).

### /contacts realtime gating (frontend)
- `buildPersonChangeFilters()`: listen `UPDATE` + `DELETE` always; `INSERT` only while a foreground mining is active.
- Channel rebuilds when `activeMiningTask` flips, so realtime stops delivering INSERTs during background mining (keep-last; new contacts appear on reload).

## Testing

- Cross-referenced NEW vs OLD stats on identical generated data (800 people, ~6.5k POC, tag edge cases): **0 diffs** across all stat columns; temperature inline == trigger formula (0 mismatches).
- Load-tested at **60k messages / 10k people / 143k POC**: backfill ~13s (under the 55s safety), incumbent re-run ~70ms, incremental +1000 msgs ~2.3s; accumulate exact (+50 → occ 7→57), no double-count, ledger fully marked, POC purged.
- Backend: lint, prettier, `tsc` build, 603 unit tests green. Frontend: lint, prettier, 18 unit tests green.
- Migration applies cleanly locally (as the non-superuser `postgres` migration role).

## Migration notes for QA/prod

- Apply `20260904000000_refine_persons_ledger_accumulate.sql`, then run one full `SELECT private.refine_persons('<user_id>')` so residual unrefined messages are accounted for.
- The realtime tenant rate-limit raise (100 → 1000 events/s) is handled in `leadminer.io` (self-hosted Supabase config) — separate PR.
